### PR TITLE
Fix the error found

### DIFF
--- a/js/popover.js
+++ b/js/popover.js
@@ -6,6 +6,8 @@ import { createElement } from './utils.js';
  * Classe pour gérer les popovers
  */
 export class Popover {
+    #handleEscape = null;
+
     /**
      * @param {string} title - Titre de la popover
      */


### PR DESCRIPTION
Ajout de la déclaration du champ privé #handleEscape au début de la classe Popover. Ce champ était utilisé sans avoir été déclaré, ce qui causait l'erreur: "Private field '#handleEscape' must be declared in an enclosing class"