### PR TITLE
Add project tile click details view

### DIFF
--- a/app.js
+++ b/app.js
@@ -546,6 +546,15 @@ class App {
         this.timerUI.renderStats(stats);
     }
 
+    /**
+     * Récupère les sessions d'un projet pour aujourd'hui
+     * @param {string} projectId - ID du projet
+     * @returns {ProjectSession[]} - Sessions du projet
+     */
+    getSessionsForProject(projectId) {
+        return this.todaySessions.filter(session => session.projectId === projectId);
+    }
+
     // ======================
     // Écouteurs d'événements
     // ======================
@@ -666,6 +675,11 @@ class App {
         // Bouton d'arrêt du timer
         this.timerUI.onStopTimer = () => {
             this.stopTimer();
+        };
+
+        // Récupération des sessions d'un projet pour affichage des détails
+        this.timerUI.onGetSessionsForProject = async (projectId) => {
+            return this.getSessionsForProject(projectId);
         };
 
         console.log('✅ Écouteurs d\'événements du chronomètre configurés');

--- a/index.html
+++ b/index.html
@@ -240,6 +240,22 @@
         <p class="footer__text">Claude Time Tracker v2.0.0</p>
     </footer>
 
+    <!-- Modal pour les détails des sessions -->
+    <div id="session-details-modal" class="modal">
+        <div class="modal__overlay"></div>
+        <div class="modal__content">
+            <div class="modal__header">
+                <h3 id="modal-project-name" class="modal__title">Détails du projet</h3>
+                <button id="close-modal-btn" class="modal__close" aria-label="Fermer">&times;</button>
+            </div>
+            <div class="modal__body">
+                <div id="sessions-list" class="sessions-list">
+                    <!-- Les sessions seront ajoutées ici dynamiquement -->
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Script principal (ES6 module) -->
     <script type="module" src="app.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -1599,3 +1599,216 @@ input[type="radio"] {
         font-size: 1rem;
     }
 }
+
+/* ============================================
+   MODAL
+   ============================================ */
+
+.modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1000;
+    align-items: center;
+    justify-content: center;
+}
+
+.modal--visible {
+    display: flex;
+}
+
+.modal__overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(2px);
+}
+
+.modal__content {
+    position: relative;
+    background-color: var(--color-surface);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
+    max-width: 600px;
+    width: 90%;
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+    animation: modalSlideIn 0.3s ease-out;
+}
+
+@keyframes modalSlideIn {
+    from {
+        opacity: 0;
+        transform: translateY(-20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.modal__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--spacing-lg);
+    border-bottom: 1px solid var(--color-border);
+}
+
+.modal__title {
+    font-size: var(--font-size-xl);
+    font-weight: 600;
+    color: var(--color-text);
+    margin: 0;
+}
+
+.modal__close {
+    background: none;
+    border: none;
+    font-size: 2rem;
+    line-height: 1;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    padding: 0;
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-sm);
+    transition: all 0.2s;
+}
+
+.modal__close:hover {
+    background-color: var(--color-border);
+    color: var(--color-text);
+}
+
+.modal__body {
+    padding: var(--spacing-lg);
+    overflow-y: auto;
+    flex: 1;
+}
+
+/* ============================================
+   SESSIONS LIST
+   ============================================ */
+
+.sessions-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-md);
+}
+
+.sessions-list__empty {
+    text-align: center;
+    color: var(--color-text-secondary);
+    padding: var(--spacing-xl);
+    font-style: italic;
+}
+
+.session-item {
+    background-color: var(--color-background);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--spacing-md);
+    transition: all 0.2s;
+}
+
+.session-item:hover {
+    border-color: var(--color-primary);
+    box-shadow: var(--shadow-sm);
+}
+
+.session-item--running {
+    background: linear-gradient(135deg, #e0f2fe 0%, #dbeafe 100%);
+    border-color: var(--color-primary);
+}
+
+.session-item__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: var(--spacing-sm);
+}
+
+.session-item__duration {
+    font-size: var(--font-size-lg);
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+.session-item__status {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+}
+
+.session-item__status--running {
+    color: var(--color-primary);
+    font-weight: 500;
+}
+
+.session-item__status-icon {
+    font-size: 1rem;
+}
+
+.session-item__details {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: var(--spacing-xs) var(--spacing-md);
+    font-size: var(--font-size-sm);
+}
+
+.session-item__label {
+    color: var(--color-text-secondary);
+    font-weight: 500;
+}
+
+.session-item__value {
+    color: var(--color-text);
+}
+
+/* Responsive modal */
+@media (max-width: 640px) {
+    .modal__content {
+        width: 95%;
+        max-height: 90vh;
+    }
+
+    .modal__header {
+        padding: var(--spacing-md);
+    }
+
+    .modal__title {
+        font-size: var(--font-size-lg);
+    }
+
+    .modal__body {
+        padding: var(--spacing-md);
+    }
+
+    .session-item__details {
+        grid-template-columns: 1fr;
+        gap: var(--spacing-xs);
+    }
+
+    .session-item__label {
+        font-weight: 600;
+    }
+}
+
+/* Curseur pointer sur les tuiles de projet */
+.project-stat-card {
+    cursor: pointer;
+    user-select: none;
+}


### PR DESCRIPTION
- Ajout d'un modal HTML pour afficher les détails des sessions
- Ajout du CSS pour le modal avec animations et responsive design
- Modification de project-timer-ui.js pour :
  * Ajouter des gestionnaires de clic sur les tuiles de projet
  * Créer des méthodes pour afficher les sessions dans un modal
  * Formater l'affichage avec début, fin, durée et statut de chaque session
- Ajout de la méthode getSessionsForProject dans app.js
- Configuration du callback onGetSessionsForProject dans setupTimerEventListeners

Les utilisateurs peuvent maintenant cliquer sur une tuile de projet pour voir la liste détaillée de toutes les sessions de travail du jour.