### PR TITLE
Simplify table last row color identification

### DIFF
--- a/app.js
+++ b/app.js
@@ -758,7 +758,7 @@ class App {
         this.reportsUI.updateSummary(this.currentReport);
 
         // Afficher le tableau hebdomadaire
-        this.reportsUI.renderWeeklyTable(this.currentReport);
+        this.reportsUI.renderWeeklyTable(this.currentReport, this.currentPeriodType);
 
         // Mettre à jour le bouton actif
         this.reportsUI.setActivePeriod(this.currentPeriodType);

--- a/js/reports-ui.js
+++ b/js/reports-ui.js
@@ -80,8 +80,9 @@ export class ReportsUI {
     /**
      * Affiche le tableau hebdomadaire avec les projets et les jours
      * @param {Object} report - Rapport avec toutes les données
+     * @param {string} periodType - Type de période ('week' ou 'month')
      */
-    renderWeeklyTable(report) {
+    renderWeeklyTable(report, periodType = 'week') {
         if (!this.weeklyTable) return;
 
         // Vider le tableau
@@ -95,6 +96,19 @@ export class ReportsUI {
             return;
         }
 
+        if (periodType === 'week') {
+            this.#renderWeekView(report);
+        } else {
+            this.#renderMonthView(report);
+        }
+    }
+
+    /**
+     * Affiche le tableau pour une semaine (lundi à vendredi)
+     * @param {Object} report - Rapport avec toutes les données
+     * @private
+     */
+    #renderWeekView(report) {
         // Filtrer uniquement les jours de la semaine (lundi à vendredi)
         const weekDays = report.dailyStats.filter(day => {
             const date = new Date(day.date + 'T12:00:00');
@@ -146,6 +160,65 @@ export class ReportsUI {
 
         // Créer la ligne de totaux
         const totalRow = this.#createTotalRow(weekDays);
+        tbody.appendChild(totalRow);
+
+        this.weeklyTable.appendChild(tbody);
+    }
+
+    /**
+     * Affiche le tableau pour un mois (toutes les semaines)
+     * @param {Object} report - Rapport avec toutes les données
+     * @private
+     */
+    #renderMonthView(report) {
+        // Grouper les jours par semaine
+        const weeks = this.#groupDaysByWeek(report.dailyStats);
+
+        if (weeks.length === 0) {
+            const emptyRow = createElement('tr');
+            const emptyCell = createElement('td', { colspan: '3' }, 'Aucune donnée pour ce mois');
+            emptyRow.appendChild(emptyCell);
+            this.weeklyTable.appendChild(emptyRow);
+            return;
+        }
+
+        // Créer l'en-tête du tableau
+        const thead = createElement('thead');
+        const headerRow = createElement('tr');
+
+        // Colonne "Projet"
+        const projectHeader = createElement('th', { class: 'weekly-table__header' }, 'Projet');
+        headerRow.appendChild(projectHeader);
+
+        // Colonnes pour chaque semaine
+        weeks.forEach((week, index) => {
+            const weekLabel = `S${index + 1}`;
+            const weekHeader = createElement('th', { class: 'weekly-table__header' }, weekLabel);
+            headerRow.appendChild(weekHeader);
+        });
+
+        // Colonne "Total"
+        const totalHeader = createElement('th', { class: 'weekly-table__header weekly-table__header--total' }, 'Total');
+        headerRow.appendChild(totalHeader);
+
+        thead.appendChild(headerRow);
+        this.weeklyTable.appendChild(thead);
+
+        // Créer le corps du tableau
+        const tbody = createElement('tbody');
+
+        // Grouper les sessions par projet
+        const sessionsByProject = this.#groupSessionsByProject(report);
+
+        // Créer une ligne pour chaque projet
+        Object.keys(sessionsByProject).forEach(projectId => {
+            const projectData = sessionsByProject[projectId];
+            const row = this.#createProjectRowForMonth(projectData, weeks);
+            tbody.appendChild(row);
+        });
+
+        // Créer la ligne de totaux
+        const totalRow = this.#createTotalRowForMonth(weeks);
         tbody.appendChild(totalRow);
 
         this.weeklyTable.appendChild(tbody);
@@ -243,10 +316,26 @@ export class ReportsUI {
     #createTotalRow(weekDays) {
         const row = createElement('tr', { class: 'weekly-table__row weekly-table__row--total' });
 
-        // Colonne du label
+        // Colonne du label avec indicateurs de couleur
         const labelCell = createElement('td', {
             class: 'weekly-table__cell weekly-table__cell--project weekly-table__cell--total-label'
-        }, 'Total');
+        });
+
+        // Ajouter les indicateurs de couleur
+        const projectIndicator = createElement('span', {
+            class: 'weekly-table__color weekly-table__color--project'
+        });
+
+        const presenceIndicator = createElement('span', {
+            class: 'weekly-table__color weekly-table__color--presence'
+        });
+
+        labelCell.appendChild(projectIndicator);
+        labelCell.appendChild(document.createTextNode(' Projets'));
+        labelCell.appendChild(document.createElement('br'));
+        labelCell.appendChild(presenceIndicator);
+        labelCell.appendChild(document.createTextNode(' Présence'));
+
         row.appendChild(labelCell);
 
         // Colonnes pour chaque jour avec temps projet et temps présence
@@ -255,11 +344,143 @@ export class ReportsUI {
 
             const projectTimeDiv = createElement('div', {
                 class: 'weekly-table__total-project'
-            }, `Projets: ${formatDuration(day.projectTime)}`);
+            }, formatDuration(day.projectTime));
 
             const presenceTimeDiv = createElement('div', {
                 class: 'weekly-table__total-presence'
-            }, `Présence: ${formatDuration(day.presenceTime)}`);
+            }, formatDuration(day.presenceTime));
+
+            cell.appendChild(projectTimeDiv);
+            cell.appendChild(presenceTimeDiv);
+            row.appendChild(cell);
+        });
+
+        // Colonne Total (vide pour la ligne de totaux)
+        const totalCell = createElement('td', { class: 'weekly-table__cell' }, '-');
+        row.appendChild(totalCell);
+
+        return row;
+    }
+
+    /**
+     * Groupe les jours par semaine
+     * @param {Object[]} dailyStats - Statistiques quotidiennes
+     * @returns {Object[]} Tableau de semaines avec leurs jours
+     * @private
+     */
+    #groupDaysByWeek(dailyStats) {
+        const weeks = [];
+        let currentWeek = [];
+
+        dailyStats.forEach((day, index) => {
+            const date = new Date(day.date + 'T12:00:00');
+            const dayOfWeek = date.getDay();
+
+            // Filtrer uniquement les jours de semaine (lundi à vendredi)
+            if (dayOfWeek >= 1 && dayOfWeek <= 5) {
+                currentWeek.push(day);
+            }
+
+            // Si c'est vendredi (5) ou le dernier jour, on termine la semaine
+            if (dayOfWeek === 5 || index === dailyStats.length - 1) {
+                if (currentWeek.length > 0) {
+                    weeks.push({
+                        days: currentWeek,
+                        projectTime: currentWeek.reduce((sum, d) => sum + d.projectTime, 0),
+                        presenceTime: currentWeek.reduce((sum, d) => sum + d.presenceTime, 0)
+                    });
+                    currentWeek = [];
+                }
+            }
+        });
+
+        return weeks;
+    }
+
+    /**
+     * Crée une ligne de projet pour l'affichage mensuel
+     * @param {Object} projectData - Données du projet
+     * @param {Object[]} weeks - Semaines du mois
+     * @returns {HTMLElement}
+     * @private
+     */
+    #createProjectRowForMonth(projectData, weeks) {
+        const row = createElement('tr', { class: 'weekly-table__row' });
+
+        // Colonne du nom du projet
+        const nameCell = createElement('td', { class: 'weekly-table__cell weekly-table__cell--project' });
+        const colorIndicator = createElement('span', {
+            class: 'weekly-table__color',
+            style: `background-color: ${projectData.projectColor || '#6b7280'}`
+        });
+        nameCell.appendChild(colorIndicator);
+        nameCell.appendChild(document.createTextNode(projectData.projectName));
+        row.appendChild(nameCell);
+
+        // Colonnes pour chaque semaine
+        weeks.forEach(week => {
+            // Calculer la durée totale du projet pour cette semaine
+            const weekDuration = week.days.reduce((sum, day) => {
+                return sum + (projectData.dailyDurations[day.date] || 0);
+            }, 0);
+
+            const cell = createElement('td', {
+                class: 'weekly-table__cell weekly-table__cell--time'
+            }, weekDuration > 0 ? formatDuration(weekDuration) : '-');
+            row.appendChild(cell);
+        });
+
+        // Colonne Total
+        const totalCell = createElement('td', {
+            class: 'weekly-table__cell weekly-table__cell--total'
+        }, formatDuration(projectData.totalDuration));
+        row.appendChild(totalCell);
+
+        return row;
+    }
+
+    /**
+     * Crée la ligne de totaux pour l'affichage mensuel
+     * @param {Object[]} weeks - Semaines du mois
+     * @returns {HTMLElement}
+     * @private
+     */
+    #createTotalRowForMonth(weeks) {
+        const row = createElement('tr', { class: 'weekly-table__row weekly-table__row--total' });
+
+        // Colonne du label avec indicateurs de couleur
+        const labelCell = createElement('td', {
+            class: 'weekly-table__cell weekly-table__cell--project weekly-table__cell--total-label'
+        });
+
+        // Ajouter les indicateurs de couleur
+        const projectIndicator = createElement('span', {
+            class: 'weekly-table__color weekly-table__color--project'
+        });
+
+        const presenceIndicator = createElement('span', {
+            class: 'weekly-table__color weekly-table__color--presence'
+        });
+
+        labelCell.appendChild(projectIndicator);
+        labelCell.appendChild(document.createTextNode(' Projets'));
+        labelCell.appendChild(document.createElement('br'));
+        labelCell.appendChild(presenceIndicator);
+        labelCell.appendChild(document.createTextNode(' Présence'));
+
+        row.appendChild(labelCell);
+
+        // Colonnes pour chaque semaine
+        weeks.forEach(week => {
+            const cell = createElement('td', { class: 'weekly-table__cell weekly-table__cell--total-time' });
+
+            const projectTimeDiv = createElement('div', {
+                class: 'weekly-table__total-project'
+            }, formatDuration(week.projectTime));
+
+            const presenceTimeDiv = createElement('div', {
+                class: 'weekly-table__total-presence'
+            }, formatDuration(week.presenceTime));
 
             cell.appendChild(projectTimeDiv);
             cell.appendChild(presenceTimeDiv);

--- a/style.css
+++ b/style.css
@@ -1179,6 +1179,14 @@ body {
     flex-shrink: 0;
 }
 
+.weekly-table__color--project {
+    background-color: var(--color-primary);
+}
+
+.weekly-table__color--presence {
+    background-color: var(--color-text-secondary);
+}
+
 .weekly-table__total-project {
     color: var(--color-primary);
     font-weight: 600;


### PR DESCRIPTION
…mensuel

- Simplification de la ligne de totaux avec indicateurs de couleur dans la première colonne
- Suppression des labels "Projets:" et "Présence:" dans chaque cellule, affichage uniquement des durées avec couleurs distinctes
- Affichage mensuel modifié pour montrer les semaines au lieu des jours individuels
- Ajout de classes CSS pour les indicateurs de couleur (projets et présence)
- Séparation de la logique d'affichage entre mode semaine et mode mois
- Mode semaine: affiche lundi à vendredi (7 colonnes avec Projet et Total)
- Mode mois: affiche toutes les semaines du mois avec leurs totaux cumulés