### PR TITLE
Create time entries management view

### DIFF
--- a/app.js
+++ b/app.js
@@ -822,11 +822,19 @@ class App {
      * Configure les écouteurs d'événements pour la gestion des entrées
      */
     setupEntriesManagementEventListeners() {
-        // Bouton pour ouvrir la vue de gestion
+        // Bouton pour ouvrir la vue de gestion (toutes les entrées)
         const manageEntriesBtn = document.getElementById('manage-entries-btn');
         if (manageEntriesBtn) {
             manageEntriesBtn.addEventListener('click', () => {
                 this.openEntriesManagement();
+            });
+        }
+
+        // Bouton pour ouvrir la vue de gestion (entrées de la période)
+        const managePeriodEntriesBtn = document.getElementById('manage-period-entries-btn');
+        if (managePeriodEntriesBtn) {
+            managePeriodEntriesBtn.addEventListener('click', () => {
+                this.openPeriodEntriesManagement();
             });
         }
 
@@ -851,9 +859,27 @@ class App {
     }
 
     /**
-     * Ouvre la vue de gestion des entrées
+     * Ouvre la vue de gestion des entrées (toutes)
      */
     async openEntriesManagement() {
+        // Réinitialiser le filtre
+        this.entriesManagementUI.clearPeriodFilter();
+        this.entriesManagementUI.show();
+        await this.loadAllEntries();
+    }
+
+    /**
+     * Ouvre la vue de gestion des entrées (période courante)
+     */
+    async openPeriodEntriesManagement() {
+        // Définir le filtre de période
+        const periodLabel = this.reportCalculator.formatDateRange(this.currentPeriodStart, this.currentPeriodEnd);
+        this.entriesManagementUI.setPeriodFilter({
+            startDate: this.currentPeriodStart,
+            endDate: this.currentPeriodEnd,
+            label: periodLabel
+        });
+
         this.entriesManagementUI.show();
         await this.loadAllEntries();
     }

--- a/index.html
+++ b/index.html
@@ -141,7 +141,12 @@
         <div class="reports-section__container">
             <!-- En-tête avec sélection de période -->
             <div class="reports-section__header">
-                <h2 class="reports-section__title">Rapports et Statistiques</h2>
+                <div class="reports-section__title-row">
+                    <h2 class="reports-section__title">Rapports et Statistiques</h2>
+                    <button id="manage-period-entries-btn" class="reports-section__manage-btn" title="Gérer les entrées de cette période">
+                        📋 Gérer les entrées de la période
+                    </button>
+                </div>
 
                 <div class="reports-section__controls">
                     <!-- Sélecteur de type de période -->

--- a/style.css
+++ b/style.css
@@ -849,6 +849,36 @@ body {
     color: var(--color-text);
 }
 
+.reports-section__title-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--spacing-md);
+}
+
+.reports-section__manage-btn {
+    padding: var(--spacing-sm) var(--spacing-lg);
+    background-color: var(--color-primary);
+    color: white;
+    border: none;
+    border-radius: var(--radius-md);
+    font-size: var(--font-size-sm);
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    white-space: nowrap;
+}
+
+.reports-section__manage-btn:hover {
+    background-color: var(--color-primary-dark);
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-md);
+}
+
+.reports-section__manage-btn:active {
+    transform: translateY(0);
+}
+
 .reports-section__controls {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
Fonctionnalités ajoutées :
- Nouveau bouton "Gérer les entrées de la période" dans la section des rapports
- Filtrage des entrées par semaine ou mois selon la période affichée
- Affichage du label de période dans la vue de gestion
- Distinction entre vue complète (header) et vue filtrée (rapports)

Modifications techniques :
- index.html : Ajout du bouton manage-period-entries-btn avec structure title-row
- style.css : Styles pour reports-section__title-row et reports-section__manage-btn
- entries-management-ui.js :
  * Ajout de la propriété periodFilter
  * Méthodes setPeriodFilter(), clearPeriodFilter(), updateInfoMessage()
  * Méthode filterEntriesByPeriod() pour filtrer par dates
  * Modification de renderAllEntries() pour appliquer le filtre
- app.js :
  * Nouvelle méthode openPeriodEntriesManagement()
  * Modification de openEntriesManagement() pour réinitialiser le filtre
  * Ajout de l'événement sur manage-period-entries-btn

UX améliorée :
- Le bouton du header affiche toutes les entrées
- Le bouton des rapports affiche uniquement les entrées de la période sélectionnée
- Message informatif adapté selon le contexte (filtré ou non)