### PR TITLE
Fix missing getTotalDuration method in sessions

### DIFF
--- a/js/sessions-management-ui.js
+++ b/js/sessions-management-ui.js
@@ -223,7 +223,7 @@ export class SessionsManagementUI {
         sessionDiv.dataset.sessionId = session.id;
 
         const projectName = projectNames.get(session.projectId) || 'Projet inconnu';
-        const duration = formatDuration(session.getTotalDuration());
+        const duration = formatDuration(session.getDuration());
         const startTime = this.formatTime(session.startTime);
         const endTime = session.endTime ? this.formatTime(session.endTime) : 'En cours';
 


### PR DESCRIPTION
Remplace getTotalDuration() par getDuration() dans la méthode createSessionElement. La classe ProjectSession n'a que la méthode getDuration(), pas getTotalDuration(). Cela corrige l'erreur "TypeError: session.getTotalDuration is not a function".