### PR TITLE
Add time entry editing with start and end hours

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,6 +19,7 @@ import { WeeklyReportCalculator } from './js/weekly-report.js';
 import { ReportsUI } from './js/reports-ui.js';
 import { EntriesManagementUI } from './js/entries-management-ui.js';
 import { SessionsManagementUI } from './js/sessions-management-ui.js';
+import { EditSessionPopover } from './js/popover.js';
 
 /**
  * Contrôleur principal de l'application
@@ -601,76 +602,40 @@ class App {
      */
     async editSessionFromManagement(session) {
         try {
-            // Demander la nouvelle heure de début
-            const currentStartTime = session.startTime.toTimeString().substring(0, 5); // HH:MM
-            const newStartTimeStr = prompt(
-                'Modifier l\'heure de début (format HH:MM):',
-                currentStartTime
-            );
+            // Trouver le nom du projet
+            const project = this.projects.find(p => p.id === session.projectId);
+            const projectName = project ? project.name : 'Projet inconnu';
 
-            if (!newStartTimeStr) return;
+            // Créer et afficher la popover d'édition
+            const popover = new EditSessionPopover(session, projectName, async (data) => {
+                try {
+                    // Mettre à jour la session
+                    session.startTime = data.startTime;
+                    session.endTime = data.endTime;
 
-            // Parser la nouvelle heure de début
-            const [startHours, startMinutes] = newStartTimeStr.split(':').map(s => parseInt(s.trim()));
+                    // Sauvegarder dans IndexedDB
+                    await this.storage.saveSession(session);
 
-            if (isNaN(startHours) || isNaN(startMinutes) || startHours < 0 || startHours > 23 || startMinutes < 0 || startMinutes > 59) {
-                this.sessionsManagementUI.showError('Format d\'heure invalide. Utilisez HH:MM');
-                return;
-            }
+                    // Recharger toutes les sessions pour rafraîchir l'affichage
+                    await this.loadAllSessions();
 
-            // Demander la nouvelle heure de fin (si la session est terminée)
-            let newEndTime = session.endTime;
-            if (session.endTime) {
-                const currentEndTime = session.endTime.toTimeString().substring(0, 5); // HH:MM
-                const newEndTimeStr = prompt(
-                    'Modifier l\'heure de fin (format HH:MM):',
-                    currentEndTime
-                );
+                    // Afficher un message de succès
+                    this.sessionsManagementUI.showSuccess?.('Session modifiée') ||
+                        this.timerUI.showSuccess('Session modifiée');
 
-                if (!newEndTimeStr) return;
-
-                // Parser la nouvelle heure de fin
-                const [endHours, endMinutes] = newEndTimeStr.split(':').map(s => parseInt(s.trim()));
-
-                if (isNaN(endHours) || isNaN(endMinutes) || endHours < 0 || endHours > 23 || endMinutes < 0 || endMinutes > 59) {
-                    this.sessionsManagementUI.showError('Format d\'heure invalide. Utilisez HH:MM');
-                    return;
+                    console.log('✅ Session modifiée:', session.id);
+                } catch (error) {
+                    console.error('❌ Erreur lors de la modification de la session:', error);
+                    this.sessionsManagementUI.showError?.('Erreur lors de la modification de la session') ||
+                        this.timerUI.showError('Erreur lors de la modification de la session');
                 }
+            });
 
-                // Créer un nouveau timestamp avec la nouvelle heure de fin
-                newEndTime = new Date(session.endTime);
-                newEndTime.setHours(endHours, endMinutes, 0, 0);
-            }
-
-            // Créer un nouveau timestamp avec la nouvelle heure de début
-            const newStartTime = new Date(session.startTime);
-            newStartTime.setHours(startHours, startMinutes, 0, 0);
-
-            // Vérifier que l'heure de début est avant l'heure de fin
-            if (newEndTime && newStartTime >= newEndTime) {
-                this.sessionsManagementUI.showError('L\'heure de début doit être avant l\'heure de fin');
-                return;
-            }
-
-            // Mettre à jour la session
-            session.startTime = newStartTime;
-            session.endTime = newEndTime;
-
-            // Sauvegarder dans IndexedDB
-            await this.storage.saveSession(session);
-
-            // Recharger toutes les sessions pour rafraîchir l'affichage
-            await this.loadAllSessions();
-
-            // Afficher un message de succès
-            this.sessionsManagementUI.showSuccess?.('Session modifiée') ||
-                this.timerUI.showSuccess('Session modifiée');
-
-            console.log('✅ Session modifiée:', session.id);
+            popover.show();
         } catch (error) {
-            console.error('❌ Erreur lors de la modification de la session:', error);
-            this.sessionsManagementUI.showError?.('Erreur lors de la modification de la session') ||
-                this.timerUI.showError('Erreur lors de la modification de la session');
+            console.error('❌ Erreur lors de l\'ouverture du popover:', error);
+            this.sessionsManagementUI.showError?.('Erreur lors de l\'ouverture du popover') ||
+                this.timerUI.showError('Erreur lors de l\'ouverture du popover');
         }
     }
 

--- a/index.html
+++ b/index.html
@@ -97,9 +97,6 @@
             <section class="projects-section">
                 <div class="projects-section__header">
                     <h2 class="projects-section__title">Projets</h2>
-                    <button id="add-manual-time-btn" class="projects-section__btn-manual-time" title="Ajouter du temps manuel">
-                        ⏰ Ajouter du temps
-                    </button>
                 </div>
 
                 <!-- Boutons d'action -->

--- a/style.css
+++ b/style.css
@@ -545,29 +545,6 @@ body {
     margin: 0;
 }
 
-.projects-section__btn-manual-time {
-    padding: var(--spacing-sm) var(--spacing-md);
-    background-color: var(--color-secondary);
-    color: white;
-    border: none;
-    border-radius: var(--radius-md);
-    font-size: var(--font-size-sm);
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    white-space: nowrap;
-}
-
-.projects-section__btn-manual-time:hover {
-    background-color: #2980b9;
-    transform: translateY(-1px);
-    box-shadow: var(--shadow-md);
-}
-
-.projects-section__btn-manual-time:active {
-    transform: translateY(0);
-}
-
 .projects-section__actions {
     display: flex;
     gap: var(--spacing-md);
@@ -861,7 +838,10 @@ body {
     gap: var(--spacing-md);
 }
 
-.reports-section__manage-btn {
+/* Style commun pour tous les boutons de gestion */
+.manage-btn,
+.reports-section__manage-btn,
+.header__manage-btn {
     padding: var(--spacing-sm) var(--spacing-lg);
     background-color: var(--color-primary);
     color: white;
@@ -874,13 +854,17 @@ body {
     white-space: nowrap;
 }
 
-.reports-section__manage-btn:hover {
+.manage-btn:hover,
+.reports-section__manage-btn:hover,
+.header__manage-btn:hover {
     background-color: var(--color-primary-dark);
     transform: translateY(-1px);
     box-shadow: var(--shadow-md);
 }
 
-.reports-section__manage-btn:active {
+.manage-btn:active,
+.reports-section__manage-btn:active,
+.header__manage-btn:active {
     transform: translateY(0);
 }
 
@@ -1701,28 +1685,7 @@ input[type="radio"] {
     flex: 1;
 }
 
-.header__manage-btn {
-    padding: var(--spacing-sm) var(--spacing-lg);
-    background-color: var(--color-primary);
-    color: white;
-    border: none;
-    border-radius: var(--radius-md);
-    font-size: var(--font-size-sm);
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    white-space: nowrap;
-}
-
-.header__manage-btn:hover {
-    background-color: var(--color-primary-dark);
-    transform: translateY(-1px);
-    box-shadow: var(--shadow-md);
-}
-
-.header__manage-btn:active {
-    transform: translateY(0);
-}
+/* Les styles header__manage-btn sont maintenant définis avec manage-btn au-dessus */
 
 /* Section de gestion des entrées (overlay plein écran) */
 .entries-management-section {


### PR DESCRIPTION
…ton Ajouter du temps

- Suppression du bouton en double 'Ajouter du temps' dans l'en-tête de la section projets
- Modification de editSessionFromManagement pour utiliser EditSessionPopover au lieu de prompts natifs
- Le popover affiche maintenant le jour, le projet, l'heure de début et l'heure de fin/durée
- Uniformisation du style de tous les boutons de gestion (Gérer les entrées, etc.)
- Import de EditSessionPopover dans app.js