### PR TITLE
Allow multiple breaks in attendance tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,12 +48,12 @@
                     <span class="presence-btn__icon">🟢</span>
                     <span class="presence-btn__text">Arrivée</span>
                 </button>
-                <button id="lunch-start-btn" class="presence-btn" disabled>
-                    <span class="presence-btn__icon">🍽️</span>
+                <button id="break-start-btn" class="presence-btn" disabled>
+                    <span class="presence-btn__icon">⏸️</span>
                     <span class="presence-btn__text">Pause</span>
                 </button>
-                <button id="lunch-end-btn" class="presence-btn" disabled>
-                    <span class="presence-btn__icon">✅</span>
+                <button id="break-end-btn" class="presence-btn" disabled>
+                    <span class="presence-btn__icon">▶️</span>
                     <span class="presence-btn__text">Reprise</span>
                 </button>
                 <button id="clock-out-btn" class="presence-btn" disabled>

--- a/js/time-entry.js
+++ b/js/time-entry.js
@@ -7,10 +7,31 @@ import { formatDate } from './utils.js';
  */
 export const ENTRY_TYPES = {
     CLOCK_IN: 'clock-in',
+    BREAK_START: 'break-start',
+    BREAK_END: 'break-end',
+    // Anciens types gardés pour compatibilité
     LUNCH_START: 'lunch-start',
     LUNCH_END: 'lunch-end',
     CLOCK_OUT: 'clock-out'
 };
+
+/**
+ * Vérifie si un type correspond à un début de pause
+ * @param {string} type - Type de pointage
+ * @returns {boolean}
+ */
+export function isBreakStart(type) {
+    return type === ENTRY_TYPES.BREAK_START || type === ENTRY_TYPES.LUNCH_START;
+}
+
+/**
+ * Vérifie si un type correspond à une fin de pause
+ * @param {string} type - Type de pointage
+ * @returns {boolean}
+ */
+export function isBreakEnd(type) {
+    return type === ENTRY_TYPES.BREAK_END || type === ENTRY_TYPES.LUNCH_END;
+}
 
 /**
  * Classe représentant un pointage (arrivée, pause, départ)

--- a/js/ui.js
+++ b/js/ui.js
@@ -12,6 +12,8 @@ export class TimeTrackerUI {
         // Cache des éléments DOM
         this.elements = {
             clockInBtn: null,
+            breakStartBtn: null,
+            breakEndBtn: null,
             lunchStartBtn: null,
             lunchEndBtn: null,
             clockOutBtn: null,
@@ -32,6 +34,8 @@ export class TimeTrackerUI {
      */
     init() {
         this.elements.clockInBtn = document.getElementById('clock-in-btn');
+        this.elements.breakStartBtn = document.getElementById('break-start-btn');
+        this.elements.breakEndBtn = document.getElementById('break-end-btn');
         this.elements.lunchStartBtn = document.getElementById('lunch-start-btn');
         this.elements.lunchEndBtn = document.getElementById('lunch-end-btn');
         this.elements.clockOutBtn = document.getElementById('clock-out-btn');
@@ -49,12 +53,21 @@ export class TimeTrackerUI {
     // ======================
 
     /**
-     * Met à jour l'état des boutons en fonction du prochain pointage attendu
-     * @param {string|null} nextExpectedEntry - Type du prochain pointage ou null
+     * Met à jour l'état des boutons en fonction des boutons à activer
+     * @param {string[]|string|null} enabledButtons - Liste des types de pointages à activer, ou type unique pour compatibilité
      */
-    updateButtons(nextExpectedEntry) {
+    updateButtons(enabledButtons) {
+        // Compatibilité : si c'est une string, la convertir en tableau
+        if (typeof enabledButtons === 'string') {
+            enabledButtons = [enabledButtons];
+        } else if (enabledButtons === null) {
+            enabledButtons = [];
+        }
+
         const buttons = {
             [ENTRY_TYPES.CLOCK_IN]: this.elements.clockInBtn,
+            [ENTRY_TYPES.BREAK_START]: this.elements.breakStartBtn,
+            [ENTRY_TYPES.BREAK_END]: this.elements.breakEndBtn,
             [ENTRY_TYPES.LUNCH_START]: this.elements.lunchStartBtn,
             [ENTRY_TYPES.LUNCH_END]: this.elements.lunchEndBtn,
             [ENTRY_TYPES.CLOCK_OUT]: this.elements.clockOutBtn
@@ -68,11 +81,13 @@ export class TimeTrackerUI {
             }
         });
 
-        // Activer le bouton approprié
-        if (nextExpectedEntry && buttons[nextExpectedEntry]) {
-            buttons[nextExpectedEntry].disabled = false;
-            buttons[nextExpectedEntry].classList.add('presence-btn--active');
-        }
+        // Activer les boutons appropriés
+        enabledButtons.forEach(entryType => {
+            if (buttons[entryType]) {
+                buttons[entryType].disabled = false;
+                buttons[entryType].classList.add('presence-btn--active');
+            }
+        });
     }
 
     /**
@@ -83,6 +98,8 @@ export class TimeTrackerUI {
     onButtonClick(entryType, callback) {
         const buttons = {
             [ENTRY_TYPES.CLOCK_IN]: this.elements.clockInBtn,
+            [ENTRY_TYPES.BREAK_START]: this.elements.breakStartBtn,
+            [ENTRY_TYPES.BREAK_END]: this.elements.breakEndBtn,
             [ENTRY_TYPES.LUNCH_START]: this.elements.lunchStartBtn,
             [ENTRY_TYPES.LUNCH_END]: this.elements.lunchEndBtn,
             [ENTRY_TYPES.CLOCK_OUT]: this.elements.clockOutBtn

--- a/js/utils.js
+++ b/js/utils.js
@@ -65,14 +65,16 @@ export function getTodayDateString() {
 
 /**
  * Convertit un type de pointage en libellé français
- * @param {string} type - Type de pointage (clock-in, lunch-start, lunch-end, clock-out)
+ * @param {string} type - Type de pointage (clock-in, break-start, break-end, clock-out)
  * @returns {string} Libellé en français
  */
 export function getEntryTypeLabel(type) {
     const labels = {
         'clock-in': 'Arrivée',
-        'lunch-start': 'Début pause',
-        'lunch-end': 'Fin pause',
+        'break-start': 'Début pause',
+        'break-end': 'Fin pause',
+        'lunch-start': 'Début pause', // Compatibilité
+        'lunch-end': 'Fin pause', // Compatibilité
         'clock-out': 'Départ'
     };
 


### PR DESCRIPTION
Modifications principales :
- Ajout des types BREAK_START/BREAK_END pour des pauses génériques
- Support de plusieurs pauses dans la journée (au lieu d'une seule)
- Arrêt automatique du timer de projet lors du début d'une pause
- Activation simultanée des boutons Pause et Départ pendant le travail
- Calcul correct du temps de présence avec multiples pauses

Détails techniques :
- time-entry.js : Nouveaux types + helpers isBreakStart/isBreakEnd
- calculator.js : Refonte de calculatePresenceTime, ajout de getBreakPairs et getEnabledButtons pour gérer plusieurs pauses et boutons actifs
- app.js : Arrêt automatique du timer lors de BREAK_START
- ui.js : Support de plusieurs boutons actifs simultanément
- index.html : Renommage lunch-btn en break-btn avec nouveaux icônes
- utils.js : Labels pour les nouveaux types de pauses

Compatibilité : Les anciens types LUNCH_START/LUNCH_END sont conservés pour la compatibilité avec les données existantes.