### PR TITLE
Fix pause button error in time tracker

### DIFF
--- a/app.js
+++ b/app.js
@@ -173,7 +173,7 @@ class App {
             if (isBreakStart(entryType) && this.timer.isRunning()) {
                 console.log('⏸️ Arrêt automatique du timer de projet lors de la pause');
                 await this.timer.stop();
-                await this.updateProjectsDisplay();
+                await this.updateProjectsUI();
             }
 
             // Créer l'entrée


### PR DESCRIPTION
Corrige l'appel à la méthode inexistante updateProjectsDisplay() en updateProjectsUI() dans la fonction recordEntry.

Cette erreur empêchait la mise à jour de l'affichage des projets lors de la prise de pause avec un timer actif.

Fixes: TypeError: this.updateProjectsDisplay is not a function