### PR TITLE
Add timeline showing project sessions and breaks

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,6 +20,7 @@ import { ReportsUI } from './js/reports-ui.js';
 import { EntriesManagementUI } from './js/entries-management-ui.js';
 import { SessionsManagementUI } from './js/sessions-management-ui.js';
 import { EditSessionPopover } from './js/popover.js';
+import { DayTimeline } from './js/day-timeline.js';
 
 /**
  * Contrôleur principal de l'application
@@ -37,6 +38,7 @@ class App {
         this.reportsUI = new ReportsUI();
         this.entriesManagementUI = new EntriesManagementUI();
         this.sessionsManagementUI = new SessionsManagementUI();
+        this.dayTimeline = new DayTimeline();
 
         // État
         this.todayEntries = [];
@@ -75,6 +77,7 @@ class App {
             this.reportsUI.init();
             this.entriesManagementUI.init();
             this.sessionsManagementUI.init();
+            this.dayTimeline.init();
 
             // Charger les données du jour
             await this.loadTodayData();
@@ -600,6 +603,9 @@ class App {
         // Calculer et afficher les statistiques
         const stats = this.calculator.calculateProjectStats(this.todaySessions, this.projects);
         this.timerUI.renderStats(stats);
+
+        // Mettre à jour la ligne de temps
+        this.dayTimeline.update(this.todayEntries, this.todaySessions, this.projects);
     }
 
     /**

--- a/index.html
+++ b/index.html
@@ -125,6 +125,19 @@
                 <div id="project-stats" class="project-stats">
                     <p class="project-stats__empty">Aucune session de travail pour aujourd'hui</p>
                 </div>
+
+                <!-- Ligne de temps de la journée -->
+                <div class="day-timeline">
+                    <div class="day-timeline__header">
+                        <h3 class="day-timeline__title">Répartition de la journée</h3>
+                        <button id="timeline-details-btn" class="day-timeline__details-btn" title="Voir le détail de la journée">
+                            📋
+                        </button>
+                    </div>
+                    <div id="day-timeline-content" class="day-timeline__content">
+                        <p class="day-timeline__empty">Aucun pointage pour aujourd'hui</p>
+                    </div>
+                </div>
             </section>
         </div>
     </main>
@@ -239,6 +252,22 @@
             <div class="modal__body">
                 <div id="sessions-list" class="sessions-list">
                     <!-- Les sessions seront ajoutées ici dynamiquement -->
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Modal pour le détail de la journée -->
+    <div id="day-details-modal" class="modal">
+        <div class="modal__overlay"></div>
+        <div class="modal__content">
+            <div class="modal__header">
+                <h3 class="modal__title">Détail de la journée</h3>
+                <button id="close-day-modal-btn" class="modal__close" aria-label="Fermer">&times;</button>
+            </div>
+            <div class="modal__body">
+                <div id="day-details-list" class="day-details-list">
+                    <!-- Le détail sera ajouté ici dynamiquement -->
                 </div>
             </div>
         </div>

--- a/js/day-timeline.js
+++ b/js/day-timeline.js
@@ -1,0 +1,399 @@
+'use strict';
+
+import { ENTRY_TYPES, isBreakStart, isBreakEnd } from './time-entry.js';
+import { formatTime } from './utils.js';
+
+/**
+ * Classe pour gérer l'affichage de la ligne de temps de la journée
+ */
+export class DayTimeline {
+    constructor() {
+        this.elements = {};
+        this.currentDayData = null;
+    }
+
+    /**
+     * Initialise les éléments du DOM
+     */
+    init() {
+        this.elements.container = document.getElementById('day-timeline-content');
+        this.elements.detailsBtn = document.getElementById('timeline-details-btn');
+        this.elements.modal = document.getElementById('day-details-modal');
+        this.elements.modalOverlay = this.elements.modal?.querySelector('.modal__overlay');
+        this.elements.closeModalBtn = document.getElementById('close-day-modal-btn');
+        this.elements.detailsList = document.getElementById('day-details-list');
+
+        this.#setupEventListeners();
+    }
+
+    /**
+     * Configure les écouteurs d'événements
+     * @private
+     */
+    #setupEventListeners() {
+        // Bouton pour ouvrir la modal de détails
+        this.elements.detailsBtn?.addEventListener('click', () => {
+            this.#showDayDetails();
+        });
+
+        // Fermer la modal
+        this.elements.closeModalBtn?.addEventListener('click', () => {
+            this.#closeDayDetails();
+        });
+
+        this.elements.modalOverlay?.addEventListener('click', () => {
+            this.#closeDayDetails();
+        });
+    }
+
+    /**
+     * Met à jour la ligne de temps avec les données du jour
+     * @param {Object[]} entries - Pointages du jour
+     * @param {Object[]} sessions - Sessions de projet du jour
+     * @param {Object[]} projects - Liste des projets
+     */
+    update(entries, sessions, projects) {
+        if (!this.elements.container) return;
+
+        // Sauvegarder les données pour les détails
+        this.currentDayData = { entries, sessions, projects };
+
+        // Vérifier s'il y a des données
+        if (!entries || entries.length === 0) {
+            this.elements.container.innerHTML = '<p class="day-timeline__empty">Aucun pointage pour aujourd\'hui</p>';
+            return;
+        }
+
+        // Trouver l'heure de début et de fin
+        const { startTime, endTime } = this.#getTimeRange(entries);
+
+        if (!startTime) {
+            this.elements.container.innerHTML = '<p class="day-timeline__empty">Aucun pointage pour aujourd\'hui</p>';
+            return;
+        }
+
+        // Créer la ligne de temps
+        this.#renderTimeline(startTime, endTime, entries, sessions, projects);
+    }
+
+    /**
+     * Détermine les bornes de temps pour la journée
+     * @param {Object[]} entries - Pointages du jour
+     * @returns {Object} { startTime, endTime }
+     * @private
+     */
+    #getTimeRange(entries) {
+        // Trouver le pointage d'arrivée (CLOCK_IN)
+        const clockInEntry = entries.find(e => e.type === ENTRY_TYPES.CLOCK_IN);
+
+        if (!clockInEntry) {
+            return { startTime: null, endTime: null };
+        }
+
+        const startTime = new Date(clockInEntry.timestamp);
+
+        // Trouver le pointage de départ (CLOCK_OUT) ou utiliser 18h00
+        const clockOutEntry = entries.find(e => e.type === ENTRY_TYPES.CLOCK_OUT);
+
+        let endTime;
+        if (clockOutEntry) {
+            endTime = new Date(clockOutEntry.timestamp);
+        } else {
+            // Utiliser 18h00 du même jour
+            endTime = new Date(startTime);
+            endTime.setHours(18, 0, 0, 0);
+        }
+
+        return { startTime, endTime };
+    }
+
+    /**
+     * Rend la ligne de temps
+     * @param {Date} startTime - Heure de début
+     * @param {Date} endTime - Heure de fin
+     * @param {Object[]} entries - Pointages
+     * @param {Object[]} sessions - Sessions de projet
+     * @param {Object[]} projects - Projets
+     * @private
+     */
+    #renderTimeline(startTime, endTime, entries, sessions, projects) {
+        // Calculer la durée totale en minutes
+        const totalDuration = (endTime - startTime) / (1000 * 60);
+
+        // Construire les segments
+        const segments = this.#buildSegments(startTime, endTime, entries, sessions, projects);
+
+        // Créer le HTML
+        const html = `
+            <div class="day-timeline__bar">
+                ${segments.map(segment => this.#renderSegment(segment, startTime, totalDuration)).join('')}
+            </div>
+            <div class="day-timeline__labels">
+                <span>${formatTime(startTime)}</span>
+                <span>${formatTime(endTime)}</span>
+            </div>
+        `;
+
+        this.elements.container.innerHTML = html;
+    }
+
+    /**
+     * Construit les segments de la ligne de temps
+     * @param {Date} startTime - Heure de début
+     * @param {Date} endTime - Heure de fin
+     * @param {Object[]} entries - Pointages
+     * @param {Object[]} sessions - Sessions de projet
+     * @param {Object[]} projects - Projets
+     * @returns {Object[]} Segments
+     * @private
+     */
+    #buildSegments(startTime, endTime, entries, sessions, projects) {
+        const segments = [];
+        const timeline = [];
+
+        // Ajouter toutes les activités avec leur type
+        // Ajouter les pauses
+        const sortedEntries = [...entries].sort((a, b) =>
+            new Date(a.timestamp) - new Date(b.timestamp)
+        );
+
+        let currentBreakStart = null;
+        sortedEntries.forEach(entry => {
+            if (isBreakStart(entry.type)) {
+                currentBreakStart = new Date(entry.timestamp);
+            } else if (isBreakEnd(entry.type) && currentBreakStart) {
+                timeline.push({
+                    type: 'break',
+                    start: currentBreakStart,
+                    end: new Date(entry.timestamp),
+                    label: 'Pause'
+                });
+                currentBreakStart = null;
+            }
+        });
+
+        // Si une pause est encore en cours
+        if (currentBreakStart) {
+            timeline.push({
+                type: 'break',
+                start: currentBreakStart,
+                end: new Date(), // Pause en cours
+                label: 'Pause (en cours)'
+            });
+        }
+
+        // Ajouter les sessions de projet
+        sessions.forEach(session => {
+            const project = projects.find(p => p.id === session.projectId);
+            const sessionStart = new Date(session.startTime);
+            const sessionEnd = session.endTime ? new Date(session.endTime) : new Date();
+
+            timeline.push({
+                type: 'project',
+                start: sessionStart,
+                end: sessionEnd,
+                label: project?.name || 'Projet inconnu',
+                projectId: session.projectId
+            });
+        });
+
+        // Trier par heure de début
+        timeline.sort((a, b) => a.start - b.start);
+
+        // Remplir les trous avec des segments "idle"
+        let currentTime = startTime;
+        timeline.forEach(item => {
+            // S'il y a un trou avant cet item
+            if (item.start > currentTime) {
+                segments.push({
+                    type: 'idle',
+                    start: currentTime,
+                    end: item.start,
+                    label: 'Inactif'
+                });
+            }
+
+            // Ajouter l'item
+            segments.push(item);
+            currentTime = item.end > currentTime ? item.end : currentTime;
+        });
+
+        // S'il reste du temps après la dernière activité
+        if (currentTime < endTime) {
+            segments.push({
+                type: 'idle',
+                start: currentTime,
+                end: endTime,
+                label: 'Inactif'
+            });
+        }
+
+        return segments;
+    }
+
+    /**
+     * Rend un segment de la ligne de temps
+     * @param {Object} segment - Segment à rendre
+     * @param {Date} startTime - Heure de début de la journée
+     * @param {number} totalDuration - Durée totale en minutes
+     * @returns {string} HTML du segment
+     * @private
+     */
+    #renderSegment(segment, startTime, totalDuration) {
+        const segmentStart = (segment.start - startTime) / (1000 * 60);
+        const segmentDuration = (segment.end - segment.start) / (1000 * 60);
+
+        const leftPercent = (segmentStart / totalDuration) * 100;
+        const widthPercent = (segmentDuration / totalDuration) * 100;
+
+        // Ne pas afficher les segments trop petits (moins de 1%)
+        if (widthPercent < 1) return '';
+
+        const duration = this.#formatDuration(segmentDuration);
+        const tooltip = `${segment.label}\n${formatTime(segment.start)} - ${formatTime(segment.end)}\n${duration}`;
+
+        return `
+            <div class="day-timeline__segment day-timeline__segment--${segment.type}"
+                 style="left: ${leftPercent}%; width: ${widthPercent}%;"
+                 title="${tooltip}">
+                <div class="day-timeline__tooltip">
+                    ${segment.label}<br>
+                    ${formatTime(segment.start)} - ${formatTime(segment.end)}<br>
+                    ${duration}
+                </div>
+                ${widthPercent > 8 ? `<span class="day-timeline__segment-label">${segment.label}</span>` : ''}
+            </div>
+        `;
+    }
+
+    /**
+     * Formate une durée en minutes
+     * @param {number} minutes - Durée en minutes
+     * @returns {string} Durée formatée
+     * @private
+     */
+    #formatDuration(minutes) {
+        const hours = Math.floor(minutes / 60);
+        const mins = Math.round(minutes % 60);
+
+        if (hours > 0) {
+            return `${hours}h ${mins.toString().padStart(2, '0')}m`;
+        }
+        return `${mins}m`;
+    }
+
+    /**
+     * Affiche la modal avec les détails de la journée
+     * @private
+     */
+    #showDayDetails() {
+        if (!this.currentDayData || !this.elements.modal) return;
+
+        const { entries, sessions, projects } = this.currentDayData;
+
+        // Créer le contenu de la modal
+        const html = this.#renderDayDetails(entries, sessions, projects);
+        this.elements.detailsList.innerHTML = html;
+
+        // Afficher la modal
+        this.elements.modal.style.display = 'block';
+        document.body.style.overflow = 'hidden';
+    }
+
+    /**
+     * Ferme la modal de détails
+     * @private
+     */
+    #closeDayDetails() {
+        if (!this.elements.modal) return;
+
+        this.elements.modal.style.display = 'none';
+        document.body.style.overflow = '';
+    }
+
+    /**
+     * Rend le détail textuel de la journée
+     * @param {Object[]} entries - Pointages
+     * @param {Object[]} sessions - Sessions de projet
+     * @param {Object[]} projects - Projets
+     * @returns {string} HTML du détail
+     * @private
+     */
+    #renderDayDetails(entries, sessions, projects) {
+        if (!entries || entries.length === 0) {
+            return '<div class="day-details-list__empty">Aucune activité pour aujourd\'hui</div>';
+        }
+
+        // Combiner toutes les activités avec leur timestamp
+        const timeline = [];
+
+        // Ajouter les pointages
+        entries.forEach(entry => {
+            const type = this.#getEntryTypeLabel(entry.type);
+            timeline.push({
+                time: new Date(entry.timestamp),
+                type: 'entry',
+                label: type,
+                subtype: entry.type
+            });
+        });
+
+        // Ajouter les sessions
+        sessions.forEach(session => {
+            const project = projects.find(p => p.id === session.projectId);
+            const duration = this.#formatDuration((new Date(session.endTime || new Date()) - new Date(session.startTime)) / (1000 * 60));
+
+            timeline.push({
+                time: new Date(session.startTime),
+                type: 'session',
+                label: `Début session: ${project?.name || 'Projet inconnu'}`,
+                duration: duration
+            });
+
+            if (session.endTime) {
+                timeline.push({
+                    time: new Date(session.endTime),
+                    type: 'session',
+                    label: `Fin session: ${project?.name || 'Projet inconnu'}`,
+                    duration: null
+                });
+            }
+        });
+
+        // Trier par ordre chronologique
+        timeline.sort((a, b) => a.time - b.time);
+
+        // Générer le HTML
+        return timeline.map(item => {
+            const className = item.type === 'entry' ?
+                (isBreakStart(item.subtype) || isBreakEnd(item.subtype) ? 'day-details-item--break' : 'day-details-item--entry') :
+                'day-details-item--session';
+
+            return `
+                <div class="day-details-item ${className}">
+                    <div class="day-details-item__time">${formatTime(item.time)}</div>
+                    <div class="day-details-item__label">${item.label}</div>
+                    ${item.duration ? `<div class="day-details-item__duration">Durée: ${item.duration}</div>` : ''}
+                </div>
+            `;
+        }).join('');
+    }
+
+    /**
+     * Obtient le libellé d'un type de pointage
+     * @param {string} type - Type de pointage
+     * @returns {string} Libellé
+     * @private
+     */
+    #getEntryTypeLabel(type) {
+        const labels = {
+            [ENTRY_TYPES.CLOCK_IN]: '🟢 Arrivée',
+            [ENTRY_TYPES.CLOCK_OUT]: '🔴 Départ',
+            [ENTRY_TYPES.BREAK_START]: '⏸️ Début de pause',
+            [ENTRY_TYPES.BREAK_END]: '▶️ Fin de pause',
+            [ENTRY_TYPES.LUNCH_START]: '⏸️ Début de pause',
+            [ENTRY_TYPES.LUNCH_END]: '▶️ Fin de pause'
+        };
+        return labels[type] || type;
+    }
+}

--- a/style.css
+++ b/style.css
@@ -798,6 +798,199 @@ body {
     margin-bottom: var(--spacing-sm);
 }
 
+/* Day Timeline */
+.day-timeline {
+    margin-top: var(--spacing-lg);
+    padding-top: var(--spacing-lg);
+    border-top: 1px solid var(--color-border);
+}
+
+.day-timeline__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: var(--spacing-md);
+}
+
+.day-timeline__title {
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+    color: var(--color-text);
+    margin: 0;
+}
+
+.day-timeline__details-btn {
+    background-color: transparent;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: var(--spacing-xs) var(--spacing-sm);
+    cursor: pointer;
+    font-size: var(--font-size-base);
+    transition: all 0.2s ease;
+}
+
+.day-timeline__details-btn:hover {
+    background-color: var(--color-background);
+    border-color: var(--color-primary);
+}
+
+.day-timeline__content {
+    position: relative;
+    min-height: 60px;
+}
+
+.day-timeline__empty {
+    color: var(--color-text-secondary);
+    text-align: center;
+    padding: var(--spacing-md);
+    font-style: italic;
+    font-size: var(--font-size-sm);
+}
+
+.day-timeline__bar {
+    position: relative;
+    height: 40px;
+    background-color: var(--color-border);
+    border-radius: var(--radius-sm);
+    overflow: visible;
+}
+
+.day-timeline__labels {
+    display: flex;
+    justify-content: space-between;
+    margin-top: var(--spacing-xs);
+    font-size: var(--font-size-xs);
+    color: var(--color-text-secondary);
+}
+
+.day-timeline__segment {
+    position: absolute;
+    top: 0;
+    height: 100%;
+    border-radius: var(--radius-xs);
+    transition: all 0.2s ease;
+    cursor: pointer;
+}
+
+.day-timeline__segment:hover {
+    opacity: 0.8;
+    transform: translateY(-2px);
+}
+
+.day-timeline__segment--project {
+    background: linear-gradient(135deg, var(--color-primary), #3b82f6);
+    border: 2px solid #2563eb;
+}
+
+.day-timeline__segment--break {
+    background: linear-gradient(135deg, #fbbf24, #f59e0b);
+    border: 2px solid #d97706;
+}
+
+.day-timeline__segment--idle {
+    background-color: #e5e7eb;
+    border: 1px dashed #9ca3af;
+}
+
+.day-timeline__segment-label {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    color: white;
+    white-space: nowrap;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+    pointer-events: none;
+}
+
+.day-timeline__segment--idle .day-timeline__segment-label {
+    color: var(--color-text-secondary);
+    text-shadow: none;
+}
+
+.day-timeline__tooltip {
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: var(--color-text);
+    color: white;
+    padding: var(--spacing-xs) var(--spacing-sm);
+    border-radius: var(--radius-sm);
+    font-size: var(--font-size-xs);
+    white-space: nowrap;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+    z-index: 1000;
+}
+
+.day-timeline__segment:hover .day-timeline__tooltip {
+    opacity: 1;
+}
+
+.day-timeline__tooltip::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 4px solid transparent;
+    border-top-color: var(--color-text);
+}
+
+/* Day Details Modal */
+.day-details-list {
+    max-height: 500px;
+    overflow-y: auto;
+}
+
+.day-details-list__empty {
+    color: var(--color-text-secondary);
+    text-align: center;
+    padding: var(--spacing-lg);
+    font-style: italic;
+}
+
+.day-details-item {
+    padding: var(--spacing-sm) var(--spacing-md);
+    border-left: 3px solid var(--color-border);
+    margin-bottom: var(--spacing-sm);
+    background-color: var(--color-surface);
+    border-radius: var(--radius-sm);
+}
+
+.day-details-item--entry {
+    border-left-color: var(--color-primary);
+}
+
+.day-details-item--session {
+    border-left-color: var(--color-success);
+}
+
+.day-details-item--break {
+    border-left-color: #f59e0b;
+}
+
+.day-details-item__time {
+    font-weight: 600;
+    color: var(--color-text);
+    margin-bottom: var(--spacing-xs);
+}
+
+.day-details-item__label {
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+}
+
+.day-details-item__duration {
+    font-size: var(--font-size-sm);
+    color: var(--color-text);
+    margin-top: var(--spacing-xs);
+}
+
 /* ======================
    RAPPORTS ET STATISTIQUES (PHASE 3)
    ====================== */


### PR DESCRIPTION
Cette fonctionnalité affiche la répartition des sessions de projet et des pauses au sein de la journée en cours sous forme de timeline visuelle.

Fonctionnalités:
- Ligne de temps horizontale montrant les sessions de projet, les pauses et les temps d'inactivité
- Utilise les heures de pointage (CLOCK_IN/CLOCK_OUT) comme bornes, avec 18h00 par défaut si pas de départ
- Segments colorés: bleu pour les projets, orange pour les pauses, gris pour l'inactivité
- Tooltips au survol montrant les détails (label, horaires, durée)
- Bouton pour ouvrir une modal avec le détail textuel complet de la journée
- Modal affichant chronologiquement tous les pointages et sessions

Fichiers modifiés:
- index.html: Ajout de la section timeline et de la modal de détail
- style.css: Styles CSS pour la timeline, segments, tooltips et modal
- js/day-timeline.js: Nouveau module gérant l'affichage de la timeline
- app.js: Intégration du module DayTimeline dans l'application