### PR TITLE
Add timeline button to daily balance sheet

### DIFF
--- a/app.js
+++ b/app.js
@@ -162,6 +162,33 @@ class App {
         }
     }
 
+    /**
+     * Charge les données d'un jour spécifique pour la timeline
+     * @param {string} date - Date au format YYYY-MM-DD
+     * @returns {Promise<Object>} Données du jour (entries, sessions, projects)
+     */
+    async loadDayData(date) {
+        try {
+            const entries = await this.storage.getEntriesByDate(date);
+            const sessions = await this.storage.getSessionsByDate(date);
+
+            console.log(`📅 Chargement des données pour ${date}: ${entries.length} entrée(s), ${sessions.length} session(s)`);
+
+            return {
+                entries,
+                sessions,
+                projects: this.projects // Utiliser les projets déjà chargés
+            };
+        } catch (error) {
+            console.error('❌ Erreur lors du chargement des données du jour:', error);
+            return {
+                entries: [],
+                sessions: [],
+                projects: []
+            };
+        }
+    }
+
     // ======================
     // Gestion des pointages
     // ======================
@@ -991,6 +1018,11 @@ class App {
         // Navigation de période
         this.reportsUI.onPeriodNavigate = (direction) => {
             this.navigatePeriod(direction);
+        };
+
+        // Demande de timeline pour un jour spécifique
+        this.reportsUI.onDayTimelineRequest = async (date) => {
+            return await this.loadDayData(date);
         };
 
         console.log('✅ Écouteurs d\'événements des rapports configurés');

--- a/index.html
+++ b/index.html
@@ -273,6 +273,22 @@
         </div>
     </div>
 
+    <!-- Modal pour la timeline d'un jour -->
+    <div id="day-timeline-modal" class="modal">
+        <div class="modal__overlay"></div>
+        <div class="modal__content">
+            <div class="modal__header">
+                <h3 id="day-timeline-modal-title" class="modal__title">Timeline du jour</h3>
+                <button id="close-day-timeline-modal-btn" class="modal__close" aria-label="Fermer">&times;</button>
+            </div>
+            <div class="modal__body">
+                <div id="day-timeline-modal-content" class="day-timeline-modal-content">
+                    <!-- La timeline sera ajoutée ici dynamiquement -->
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Script principal (ES6 module) -->
     <script type="module" src="app.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -1397,6 +1397,43 @@ body {
     font-weight: 500;
 }
 
+.weekly-table__header-content {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--spacing-xs);
+}
+
+.weekly-table__header-date {
+    flex: 1;
+}
+
+.weekly-table__timeline-btn {
+    background: rgba(255, 255, 255, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: var(--border-radius);
+    padding: 2px 6px;
+    font-size: 14px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    color: white;
+    line-height: 1;
+}
+
+.weekly-table__timeline-btn:hover {
+    background: rgba(255, 255, 255, 0.3);
+    border-color: rgba(255, 255, 255, 0.5);
+    transform: scale(1.1);
+}
+
+.weekly-table__timeline-btn:active {
+    transform: scale(0.95);
+}
+
+.day-timeline-modal-content {
+    min-height: 150px;
+}
+
 /* ======================
    Popover
    ====================== */


### PR DESCRIPTION
Implémentation d'une fonctionnalité permettant d'ouvrir la timeline d'un jour spécifique directement depuis le tableau de bilan hebdomadaire.

Changements:
- Ajout d'une icône cliquable (📊) à côté de chaque date dans les en-têtes du tableau
- Création d'une nouvelle modale pour afficher la timeline d'un jour sélectionné
- Implémentation de la logique de chargement des données (entrées et sessions) pour une date spécifique
- Ajout des styles CSS pour le bouton et la modale
- Connexion du callback dans app.js pour charger les données du jour

Fichiers modifiés:
- index.html: ajout de la modale day-timeline-modal
- js/reports-ui.js: ajout du bouton timeline, de la modale et de la logique d'affichage
- app.js: ajout de la méthode loadDayData et connexion du callback
- style.css: styles pour le bouton timeline et la modale