### PR TITLE
Stop active task when clocking out

### DIFF
--- a/app.js
+++ b/app.js
@@ -184,6 +184,13 @@ class App {
                 await this.updateProjectsUI();
             }
 
+            // Si on pointe son départ, arrêter le timer de projet en cours
+            if (entryType === ENTRY_TYPES.CLOCK_OUT && this.timer.isRunning()) {
+                console.log('⏹️ Arrêt automatique du timer de projet lors du départ');
+                await this.timer.stop();
+                await this.loadTodaySessions();
+            }
+
             // Si on termine une pause, redémarrer le projet qui était actif avant la pause
             if (isBreakEnd(entryType)) {
                 const pausedProjectId = localStorage.getItem('pausedProjectId');


### PR DESCRIPTION
Ajout de la logique pour arrêter automatiquement le timer de projet lorsqu'un utilisateur pointe son départ (clock out) en fin de journée.

Cette fonctionnalité suit le même pattern que l'arrêt automatique lors des pauses, mais sans sauvegarde pour reprise automatique car il s'agit de la fin de journée.

Modifié: app.js (lignes 184-189)