### PR TITLE
Fix tooltip visibility and session end timing

### DIFF
--- a/app.js
+++ b/app.js
@@ -214,8 +214,24 @@ class App {
             // Si on pointe son départ, arrêter le timer de projet en cours
             if (entryType === ENTRY_TYPES.CLOCK_OUT && this.timer.isRunning()) {
                 console.log('⏹️ Arrêt automatique du timer de projet lors du départ');
-                await this.timer.stop();
+                // Créer le timestamp du pointage
+                const clockOutTime = new Date();
+                // Arrêter la session juste avant le pointage (1 seconde avant)
+                const sessionEndTime = new Date(clockOutTime.getTime() - 1000);
+                await this.timer.stop(sessionEndTime);
                 await this.loadTodaySessions();
+
+                // Créer et enregistrer l'entrée de pointage avec le timestamp correct
+                const entry = new TimeEntry(entryType, clockOutTime);
+                await this.storage.saveEntry(entry);
+                this.todayEntries.push(entry);
+
+                // Mettre à jour tous les affichages
+                await this.updateAllDisplays();
+
+                this.ui.showSuccess('Départ enregistré');
+                console.log('✅ Pointage enregistré:', entryType);
+                return;
             }
 
             // Si on termine une pause, redémarrer le projet qui était actif avant la pause

--- a/js/timer.js
+++ b/js/timer.js
@@ -72,17 +72,18 @@ export class ProjectTimer {
 
     /**
      * Arrête le chronomètre en cours
+     * @param {Date} endTime - Heure de fin optionnelle (par défaut: maintenant)
      * @returns {Promise<ProjectSession|null>} Session terminée ou null
      * @throws {Error} Si aucun chronomètre n'est en cours
      */
-    async stop() {
+    async stop(endTime = new Date()) {
         try {
             if (!this.currentSession) {
                 throw new Error('Aucun chronomètre n\'est en cours');
             }
 
-            // Arrêter la session
-            this.currentSession.stop();
+            // Arrêter la session avec l'heure spécifiée
+            this.currentSession.stop(endTime);
 
             // Sauvegarder dans IndexedDB
             await this.storage.saveSession(this.currentSession);

--- a/style.css
+++ b/style.css
@@ -920,7 +920,9 @@ body {
     padding: var(--spacing-xs) var(--spacing-sm);
     border-radius: var(--radius-sm);
     font-size: var(--font-size-xs);
-    white-space: nowrap;
+    white-space: normal;
+    max-width: 200px;
+    text-align: center;
     pointer-events: none;
     opacity: 0;
     transition: opacity 0.2s ease;


### PR DESCRIPTION
1. Fixed tooltip styling to prevent overflow:
   - Changed white-space from nowrap to normal to allow text wrapping
   - Added max-width of 200px to limit tooltip size
   - Added text-align center for better appearance

2. Fixed session end time when clocking out:
   - Modified ProjectTimer.stop() to accept optional endTime parameter
   - Session now ends 1 second before clockout timestamp
   - Ensures logical timeline: session ends, then clockout occurs