### PR TITLE
Fix period navigation buttons not working

### DIFF
--- a/app.js
+++ b/app.js
@@ -938,13 +938,15 @@ class App {
      */
     async loadCurrentReport() {
         try {
-            // Définir la période en fonction du type
-            if (this.currentPeriodType === 'week') {
-                this.currentPeriodStart = this.reportCalculator.getWeekStart();
-                this.currentPeriodEnd = this.reportCalculator.getWeekEnd();
-            } else {
-                this.currentPeriodStart = this.reportCalculator.getMonthStart();
-                this.currentPeriodEnd = this.reportCalculator.getMonthEnd();
+            // Définir la période en fonction du type (seulement si pas déjà définie)
+            if (!this.currentPeriodStart || !this.currentPeriodEnd) {
+                if (this.currentPeriodType === 'week') {
+                    this.currentPeriodStart = this.reportCalculator.getWeekStart();
+                    this.currentPeriodEnd = this.reportCalculator.getWeekEnd();
+                } else {
+                    this.currentPeriodStart = this.reportCalculator.getMonthStart();
+                    this.currentPeriodEnd = this.reportCalculator.getMonthEnd();
+                }
             }
 
             // Charger toutes les données nécessaires pour la période
@@ -1006,6 +1008,9 @@ class App {
      */
     async changePeriodType(periodType) {
         this.currentPeriodType = periodType;
+        // Réinitialiser les dates lors du changement de type
+        this.currentPeriodStart = null;
+        this.currentPeriodEnd = null;
         await this.loadCurrentReport();
     }
 


### PR DESCRIPTION
Le problème était que loadCurrentReport() écrasait systématiquement les dates currentPeriodStart et currentPeriodEnd avec les dates de la période actuelle, empêchant ainsi la navigation vers les périodes précédentes/suivantes.

Modifications :
- loadCurrentReport() : initialise les dates uniquement si elles ne sont pas déjà définies
- changePeriodType() : réinitialise les dates lors du changement de type de période

Les boutons de navigation (← et →) fonctionnent maintenant correctement pour naviguer entre les semaines et les mois.