### PR TITLE
Add edit functionality to weekly attendance times

### DIFF
--- a/app.js
+++ b/app.js
@@ -1053,6 +1053,11 @@ class App {
             return await this.loadDayData(date);
         };
 
+        // Clic sur le temps de présence pour éditer les pointages
+        this.reportsUI.onPresenceTimeClick = async (date) => {
+            await this.openDayEntriesManagement(date);
+        };
+
         console.log('✅ Écouteurs d\'événements des rapports configurés');
     }
 
@@ -1141,6 +1146,30 @@ class App {
 
         this.sessionsManagementUI.show();
         await this.loadAllSessions();
+    }
+
+    /**
+     * Ouvre la vue de gestion des entrées pour un jour spécifique
+     * @param {string} date - Date au format YYYY-MM-DD
+     */
+    async openDayEntriesManagement(date) {
+        // Convertir la date en Date objects
+        const dateObj = new Date(date + 'T12:00:00');
+
+        // Créer un label lisible pour la date
+        const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+        const dateLabel = dateObj.toLocaleDateString('fr-FR', options);
+        const formattedLabel = dateLabel.charAt(0).toUpperCase() + dateLabel.slice(1);
+
+        // Définir le filtre de période pour un seul jour
+        this.entriesManagementUI.setPeriodFilter({
+            startDate: dateObj,
+            endDate: dateObj,
+            label: formattedLabel
+        });
+
+        this.entriesManagementUI.show();
+        await this.loadAllEntries();
     }
 
     /**

--- a/js/reports-ui.js
+++ b/js/reports-ui.js
@@ -28,6 +28,7 @@ export class ReportsUI {
         this.onPeriodTypeChange = null;
         this.onPeriodNavigate = null;
         this.onDayTimelineRequest = null; // Callback pour charger les données d'un jour
+        this.onPresenceTimeClick = null; // Callback pour gérer le clic sur le temps de présence
     }
 
     /**
@@ -388,8 +389,17 @@ export class ReportsUI {
             }, formatDuration(day.projectTime));
 
             const presenceTimeDiv = createElement('div', {
-                class: 'weekly-table__total-presence'
+                class: 'weekly-table__total-presence weekly-table__total-presence--clickable',
+                'data-date': day.date,
+                title: 'Cliquez pour modifier les pointages de ce jour'
             }, formatDuration(day.presenceTime));
+
+            // Ajouter un event listener pour rendre le temps de présence cliquable
+            presenceTimeDiv.addEventListener('click', () => {
+                if (this.onPresenceTimeClick && day.hasEntries) {
+                    this.onPresenceTimeClick(day.date);
+                }
+            });
 
             cell.appendChild(projectTimeDiv);
             cell.appendChild(presenceTimeDiv);
@@ -529,6 +539,9 @@ export class ReportsUI {
             const presenceTimeDiv = createElement('div', {
                 class: 'weekly-table__total-presence'
             }, formatDuration(week.presenceTime));
+
+            // Note: Pour la vue mensuelle, on ne rend pas le temps de présence cliquable
+            // car il représente une semaine entière, pas un jour spécifique
 
             cell.appendChild(projectTimeDiv);
             cell.appendChild(presenceTimeDiv);

--- a/style.css
+++ b/style.css
@@ -1399,6 +1399,19 @@ body {
     font-weight: 500;
 }
 
+.weekly-table__total-presence--clickable {
+    cursor: pointer;
+    transition: all 0.2s ease;
+    padding: 2px 4px;
+    border-radius: 4px;
+}
+
+.weekly-table__total-presence--clickable:hover {
+    background-color: rgba(99, 102, 241, 0.1);
+    color: var(--color-primary);
+    font-weight: 600;
+}
+
 .weekly-table__header-content {
     display: flex;
     align-items: center;


### PR DESCRIPTION
…emps de présence

- Rendre le temps de présence cliquable dans la ligne de totaux du tableau hebdomadaire
- Ajouter un callback onPresenceTimeClick dans ReportsUI
- Créer la méthode openDayEntriesManagement dans App pour ouvrir l'interface de gestion des entrées avec un filtre sur un jour spécifique
- Ajouter les styles CSS pour indiquer visuellement que le temps de présence est cliquable (curseur pointer, effet hover)
- La fonctionnalité n'est active que pour la vue hebdomadaire, pas pour la vue mensuelle

Lorsque l'utilisateur clique sur le temps de présence d'une journée dans le tableau hebdomadaire, l'interface de gestion des entrées s'ouvre avec un filtre automatique sur cette journée spécifique, permettant de modifier facilement les pointages.