### PR TITLE
Fix add timesheet button in entry management popup

### DIFF
--- a/js/entries-management-ui.js
+++ b/js/entries-management-ui.js
@@ -457,7 +457,7 @@ export class EntriesManagementUI {
         }
 
         // Afficher le modal
-        this.addEntryModal.classList.add('modal--active');
+        this.addEntryModal.classList.add('modal--visible');
     }
 
     /**
@@ -466,7 +466,7 @@ export class EntriesManagementUI {
     hideAddEntryModal() {
         if (!this.addEntryModal) return;
 
-        this.addEntryModal.classList.remove('modal--active');
+        this.addEntryModal.classList.remove('modal--visible');
 
         // Réinitialiser le formulaire
         if (this.addEntryForm) {


### PR DESCRIPTION
Le bouton "Ajouter un pointage" ne fonctionnait pas car le code utilisait la classe CSS 'modal--active' alors que le CSS définit 'modal--visible'.

Changements:
- Remplacer 'modal--active' par 'modal--visible' dans showAddEntryModal()
- Remplacer 'modal--active' par 'modal--visible' dans hideAddEntryModal()

Le modal s'affiche maintenant correctement quand on clique sur le bouton.