### PR TITLE
Fix timesheet entry not updating after edit

### DIFF
--- a/app.js
+++ b/app.js
@@ -452,6 +452,16 @@ class App {
         // Si le modal est ouvert, le rafraîchir
         this.refreshModalIfOpen();
 
+        // Si la section de gestion des entrées est visible, la rafraîchir
+        if (this.entriesManagementUI.section?.classList.contains('entries-management-section--visible')) {
+            await this.loadAllEntries();
+        }
+
+        // Si la section de gestion des sessions est visible, la rafraîchir
+        if (this.sessionsManagementUI.section?.classList.contains('entries-management-section--visible')) {
+            await this.loadAllSessions();
+        }
+
         // Rafraîchir le rapport hebdomadaire pour refléter les changements immédiatement
         await this.loadCurrentReport();
     }


### PR DESCRIPTION
…ointage

Correction du problème où l'heure d'un pointage modifié n'était pas mise à jour immédiatement dans la popover de gestion des pointages.

Changements:
- Ajout de la mise à jour automatique de entriesManagementUI dans updateAllDisplays()
- Ajout de la mise à jour automatique de sessionsManagementUI dans updateAllDisplays()
- Les sections de gestion sont maintenant rafraîchies si elles sont visibles

L'utilisateur n'a plus besoin de fermer et réouvrir la popover pour voir les modifications appliquées.