### PR TITLE
Add multi-project session tracking feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,9 +89,33 @@
                 <div class="timer-compact__time">
                     <span id="timer-duration" class="timer-compact__duration">0h 00m</span>
                 </div>
-                <button id="stop-timer-btn" class="timer-compact__stop-btn" disabled>
-                    ⏹️ Arrêter
-                </button>
+                <div class="timer-compact__actions">
+                    <button id="stop-timer-btn" class="timer-compact__stop-btn" disabled>
+                        ⏹️ Arrêter
+                    </button>
+                    <button id="stop-all-timers-btn" class="timer-compact__stop-all-btn" disabled title="Arrêter tous les chronomètres">
+                        ⏹️ Tout arrêter
+                    </button>
+                </div>
+                <!-- Toggle mode multi-projet -->
+                <div class="timer-compact__mode-toggle">
+                    <label class="toggle-switch" title="Permet de travailler sur plusieurs projets simultanément">
+                        <input type="checkbox" id="multi-project-toggle">
+                        <span class="toggle-switch__slider"></span>
+                    </label>
+                    <span class="toggle-switch__label">Multi-projet</span>
+                </div>
+            </section>
+
+            <!-- Liste des sessions actives (mode multi-projet) -->
+            <section class="active-sessions" id="active-sessions" style="display: none;">
+                <div class="active-sessions__header">
+                    <span class="active-sessions__title">Sessions actives</span>
+                    <span class="active-sessions__count" id="active-sessions-count">0</span>
+                </div>
+                <div class="active-sessions__list" id="active-sessions-list">
+                    <!-- Sessions actives ajoutées dynamiquement -->
+                </div>
             </section>
 
             <!-- Gestion des projets -->

--- a/js/model/model.js
+++ b/js/model/model.js
@@ -33,10 +33,16 @@ export const initialModel = Object.freeze({
     sessions: [],
 
     /**
-     * Session de projet en cours (si une est active)
-     * @type {ProjectSession|null}
+     * Sessions de projet en cours (peut contenir plusieurs sessions si multiProjectMode est actif)
+     * @type {Array<ProjectSession>}
      */
-    currentSession: null,
+    currentSessions: [],
+
+    /**
+     * Mode multi-projet activé (permet plusieurs sessions simultanées)
+     * @type {boolean}
+     */
+    multiProjectMode: false,
 
     // ===== État UI =====
 
@@ -240,17 +246,38 @@ export const selectors = Object.freeze({
      * @returns {boolean}
      */
     isTimerRunning: (model) =>
-        model.currentSession !== null,
+        model.currentSessions && model.currentSessions.length > 0,
 
     /**
-     * Obtient le projet de la session en cours
+     * Obtient le projet de la première session en cours (pour compatibilité)
      * @param {Object} model - Modèle
      * @returns {Object|null} Projet ou null
      */
     getCurrentProject: (model) => {
-        if (!model.currentSession) return null;
-        return model.projects.find(p => p.id === model.currentSession.projectId) || null;
+        if (!model.currentSessions || model.currentSessions.length === 0) return null;
+        return model.projects.find(p => p.id === model.currentSessions[0].projectId) || null;
     },
+
+    /**
+     * Obtient tous les projets avec des sessions en cours
+     * @param {Object} model - Modèle
+     * @returns {Array} Projets actifs
+     */
+    getCurrentProjects: (model) => {
+        if (!model.currentSessions || model.currentSessions.length === 0) return [];
+        return model.currentSessions
+            .map(session => model.projects.find(p => p.id === session.projectId))
+            .filter(p => p !== undefined);
+    },
+
+    /**
+     * Vérifie si un projet spécifique a une session en cours
+     * @param {Object} model - Modèle
+     * @param {string} projectId - ID du projet
+     * @returns {boolean}
+     */
+    isProjectRunning: (model, projectId) =>
+        model.currentSessions && model.currentSessions.some(s => s.projectId === projectId),
 
     /**
      * Vérifie si l'objectif de 8h est atteint

--- a/js/storage.js
+++ b/js/storage.js
@@ -510,11 +510,11 @@ export class StorageService {
     }
 
     /**
-     * Récupère la session en cours (non terminée) s'il y en a une
-     * @returns {Promise<ProjectSession|null>} Session en cours ou null
+     * Récupère toutes les sessions en cours (non terminées)
+     * @returns {Promise<ProjectSession[]>} Sessions en cours
      * @throws {Error} Si la récupération échoue
      */
-    async getCurrentSession() {
+    async getCurrentSessions() {
         return new Promise((resolve, reject) => {
             const transaction = this.db.transaction([STORES.PROJECT_SESSIONS], 'readonly');
             const store = transaction.objectStore(STORES.PROJECT_SESSIONS);
@@ -526,18 +526,23 @@ export class StorageService {
                     .map(data => ProjectSession.fromJSON(data))
                     .filter(session => session.isRunning());
 
-                // Il ne devrait y avoir qu'une seule session en cours
-                if (sessions.length > 0) {
-                    resolve(sessions[0]);
-                } else {
-                    resolve(null);
-                }
+                resolve(sessions);
             };
 
             request.onerror = () => {
-                reject(new Error('Erreur lors de la récupération de la session en cours'));
+                reject(new Error('Erreur lors de la récupération des sessions en cours'));
             };
         });
+    }
+
+    /**
+     * Récupère la première session en cours (pour compatibilité)
+     * @returns {Promise<ProjectSession|null>} Session en cours ou null
+     * @throws {Error} Si la récupération échoue
+     */
+    async getCurrentSession() {
+        const sessions = await this.getCurrentSessions();
+        return sessions.length > 0 ? sessions[0] : null;
     }
 
     /**

--- a/js/timer.js
+++ b/js/timer.js
@@ -4,30 +4,41 @@ import { ProjectSession } from './project-session.js';
 
 /**
  * Gestion du chronomètre pour les projets
+ * Supporte le mode multi-projet (plusieurs sessions simultanées)
  */
 export class ProjectTimer {
     constructor(storage) {
         this.storage = storage;
-        this.currentSession = null;
+        this.currentSessions = []; // Tableau de sessions actives
         this.updateInterval = null;
+        this.multiProjectMode = false; // Mode multi-projet désactivé par défaut
+
+        // Callbacks
         this.onTick = null; // Callback appelé chaque seconde
         this.onStart = null; // Callback appelé au démarrage
         this.onStop = null; // Callback appelé à l'arrêt
+        this.onModeChange = null; // Callback appelé lors du changement de mode
     }
 
     /**
-     * Initialise le timer (charge la session en cours s'il y en a une)
+     * Initialise le timer (charge les sessions en cours s'il y en a)
      */
     async init() {
         try {
-            this.currentSession = await this.storage.getCurrentSession();
+            // Charger le mode multi-projet depuis localStorage
+            this.multiProjectMode = localStorage.getItem('multiProjectMode') === 'true';
 
-            if (this.currentSession) {
-                console.log('⏱️ Session en cours trouvée:', this.currentSession.projectId);
+            // Charger toutes les sessions en cours
+            this.currentSessions = await this.storage.getCurrentSessions();
+
+            if (this.currentSessions.length > 0) {
+                console.log(`⏱️ ${this.currentSessions.length} session(s) en cours trouvée(s)`);
                 this.#startUpdateLoop();
 
                 if (this.onStart) {
-                    this.onStart(this.currentSession.projectId, this.currentSession.getDuration());
+                    this.currentSessions.forEach(session => {
+                        this.onStart(session.projectId, session.getDuration());
+                    });
                 }
             }
         } catch (error) {
@@ -37,26 +48,61 @@ export class ProjectTimer {
     }
 
     /**
+     * Active ou désactive le mode multi-projet
+     * @param {boolean} enabled - true pour activer, false pour désactiver
+     */
+    setMultiProjectMode(enabled) {
+        this.multiProjectMode = enabled;
+        localStorage.setItem('multiProjectMode', enabled.toString());
+
+        console.log(`🔄 Mode multi-projet ${enabled ? 'activé' : 'désactivé'}`);
+
+        if (this.onModeChange) {
+            this.onModeChange(enabled);
+        }
+    }
+
+    /**
+     * Vérifie si le mode multi-projet est actif
+     * @returns {boolean}
+     */
+    isMultiProjectMode() {
+        return this.multiProjectMode;
+    }
+
+    /**
      * Démarre le chronomètre pour un projet
      * @param {string} projectId - ID du projet
      * @returns {Promise<void>}
-     * @throws {Error} Si un chronomètre est déjà en cours
+     * @throws {Error} Si le mode mono-projet et qu'un chronomètre est déjà en cours
      */
     async start(projectId) {
         try {
-            // Vérifier qu'il n'y a pas déjà un chronomètre en cours
-            if (this.currentSession) {
-                throw new Error('Un chronomètre est déjà en cours. Arrêtez-le avant d\'en démarrer un nouveau.');
+            // Vérifier si ce projet a déjà une session en cours
+            const existingSession = this.currentSessions.find(s => s.projectId === projectId);
+            if (existingSession) {
+                console.log('⚠️ Une session existe déjà pour ce projet');
+                return;
+            }
+
+            // En mode mono-projet, vérifier qu'il n'y a pas déjà un chronomètre en cours
+            if (!this.multiProjectMode && this.currentSessions.length > 0) {
+                throw new Error('Un chronomètre est déjà en cours. Activez le mode multi-projet ou arrêtez-le avant d\'en démarrer un nouveau.');
             }
 
             // Créer une nouvelle session
-            this.currentSession = new ProjectSession(projectId);
+            const newSession = new ProjectSession(projectId);
 
             // Sauvegarder dans IndexedDB
-            await this.storage.saveSession(this.currentSession);
+            await this.storage.saveSession(newSession);
 
-            // Démarrer la boucle de mise à jour
-            this.#startUpdateLoop();
+            // Ajouter à la liste des sessions actives
+            this.currentSessions.push(newSession);
+
+            // Démarrer la boucle de mise à jour si c'est la première session
+            if (this.currentSessions.length === 1) {
+                this.#startUpdateLoop();
+            }
 
             // Callback
             if (this.onStart) {
@@ -71,40 +117,50 @@ export class ProjectTimer {
     }
 
     /**
-     * Arrête le chronomètre en cours
+     * Arrête le chronomètre pour un projet spécifique
+     * @param {string} projectId - ID du projet (optionnel, si non fourni arrête la première session)
      * @param {Date} endTime - Heure de fin optionnelle (par défaut: maintenant)
      * @returns {Promise<ProjectSession|null>} Session terminée ou null
-     * @throws {Error} Si aucun chronomètre n'est en cours
      */
-    async stop(endTime = new Date()) {
+    async stop(projectId = null, endTime = new Date()) {
         try {
-            if (!this.currentSession) {
-                throw new Error('Aucun chronomètre n\'est en cours');
+            let sessionToStop;
+
+            if (projectId) {
+                // Trouver la session du projet spécifié
+                sessionToStop = this.currentSessions.find(s => s.projectId === projectId);
+            } else {
+                // Prendre la première session (comportement par défaut)
+                sessionToStop = this.currentSessions[0];
+            }
+
+            if (!sessionToStop) {
+                throw new Error('Aucun chronomètre n\'est en cours' + (projectId ? ' pour ce projet' : ''));
             }
 
             // Arrêter la session avec l'heure spécifiée
-            this.currentSession.stop(endTime);
+            sessionToStop.stop(endTime);
 
             // Sauvegarder dans IndexedDB
-            await this.storage.saveSession(this.currentSession);
+            await this.storage.saveSession(sessionToStop);
 
-            // Arrêter la boucle de mise à jour
-            this.#stopUpdateLoop();
+            // Retirer de la liste des sessions actives
+            this.currentSessions = this.currentSessions.filter(s => s.id !== sessionToStop.id);
 
-            const finishedSession = this.currentSession;
+            // Arrêter la boucle de mise à jour s'il n'y a plus de sessions
+            if (this.currentSessions.length === 0) {
+                this.#stopUpdateLoop();
+            }
 
             // Callback
             if (this.onStop) {
-                this.onStop(finishedSession.projectId, finishedSession.getDuration());
+                this.onStop(sessionToStop.projectId, sessionToStop.getDuration());
             }
 
-            console.log('⏹️ Chronomètre arrêté pour le projet:', finishedSession.projectId);
-            console.log(`   Durée: ${Math.floor(finishedSession.getDuration() / 1000)} secondes`);
+            console.log('⏹️ Chronomètre arrêté pour le projet:', sessionToStop.projectId);
+            console.log(`   Durée: ${Math.floor(sessionToStop.getDuration() / 1000)} secondes`);
 
-            // Réinitialiser
-            this.currentSession = null;
-
-            return finishedSession;
+            return sessionToStop;
         } catch (error) {
             console.error('❌ Erreur lors de l\'arrêt du chronomètre:', error);
             throw error;
@@ -112,19 +168,43 @@ export class ProjectTimer {
     }
 
     /**
+     * Arrête tous les chronomètres en cours
+     * @param {Date} endTime - Heure de fin optionnelle (par défaut: maintenant)
+     * @returns {Promise<ProjectSession[]>} Sessions terminées
+     */
+    async stopAll(endTime = new Date()) {
+        const stoppedSessions = [];
+
+        while (this.currentSessions.length > 0) {
+            const session = await this.stop(null, endTime);
+            if (session) {
+                stoppedSessions.push(session);
+            }
+        }
+
+        return stoppedSessions;
+    }
+
+    /**
      * Bascule vers un autre projet (arrête le chronomètre actuel et en démarre un nouveau)
+     * En mode mono-projet uniquement
      * @param {string} newProjectId - ID du nouveau projet
      * @returns {Promise<void>}
      */
     async switchTo(newProjectId) {
         try {
-            // Arrêter le chronomètre actuel s'il y en a un
-            if (this.currentSession) {
-                await this.stop();
-            }
+            if (this.multiProjectMode) {
+                // En mode multi-projet, juste démarrer le nouveau projet
+                await this.start(newProjectId);
+            } else {
+                // En mode mono-projet, arrêter d'abord le chronomètre actuel
+                if (this.currentSessions.length > 0) {
+                    await this.stop();
+                }
 
-            // Démarrer un nouveau chronomètre
-            await this.start(newProjectId);
+                // Démarrer un nouveau chronomètre
+                await this.start(newProjectId);
+            }
 
             console.log('🔄 Basculé vers le projet:', newProjectId);
         } catch (error) {
@@ -134,23 +214,57 @@ export class ProjectTimer {
     }
 
     /**
-     * Récupère le temps écoulé de la session en cours
-     * @returns {number} Durée en millisecondes (0 si aucune session)
+     * Récupère le temps écoulé total de toutes les sessions en cours
+     * @returns {number} Durée totale en millisecondes
      */
-    getElapsedTime() {
-        if (!this.currentSession) {
-            return 0;
-        }
-
-        return this.currentSession.getDuration();
+    getTotalElapsedTime() {
+        return this.currentSessions.reduce((total, session) => total + session.getDuration(), 0);
     }
 
     /**
-     * Récupère l'ID du projet en cours
+     * Récupère le temps écoulé de la première session en cours (pour compatibilité)
+     * @returns {number} Durée en millisecondes (0 si aucune session)
+     */
+    getElapsedTime() {
+        if (this.currentSessions.length === 0) {
+            return 0;
+        }
+
+        return this.currentSessions[0].getDuration();
+    }
+
+    /**
+     * Récupère le temps écoulé pour un projet spécifique
+     * @param {string} projectId - ID du projet
+     * @returns {number} Durée en millisecondes (0 si pas de session)
+     */
+    getElapsedTimeForProject(projectId) {
+        const session = this.currentSessions.find(s => s.projectId === projectId);
+        return session ? session.getDuration() : 0;
+    }
+
+    /**
+     * Récupère l'ID du premier projet en cours (pour compatibilité)
      * @returns {string|null} ID du projet ou null
      */
     getCurrentProjectId() {
-        return this.currentSession ? this.currentSession.projectId : null;
+        return this.currentSessions.length > 0 ? this.currentSessions[0].projectId : null;
+    }
+
+    /**
+     * Récupère les IDs de tous les projets en cours
+     * @returns {string[]} IDs des projets
+     */
+    getCurrentProjectIds() {
+        return this.currentSessions.map(s => s.projectId);
+    }
+
+    /**
+     * Récupère toutes les sessions en cours
+     * @returns {ProjectSession[]}
+     */
+    getCurrentSessions() {
+        return [...this.currentSessions];
     }
 
     /**
@@ -158,7 +272,24 @@ export class ProjectTimer {
      * @returns {boolean}
      */
     isRunning() {
-        return this.currentSession !== null;
+        return this.currentSessions.length > 0;
+    }
+
+    /**
+     * Vérifie si un projet spécifique a un chronomètre en cours
+     * @param {string} projectId - ID du projet
+     * @returns {boolean}
+     */
+    isRunningForProject(projectId) {
+        return this.currentSessions.some(s => s.projectId === projectId);
+    }
+
+    /**
+     * Récupère le nombre de sessions actives
+     * @returns {number}
+     */
+    getActiveSessionCount() {
+        return this.currentSessions.length;
     }
 
     /**
@@ -169,9 +300,12 @@ export class ProjectTimer {
         this.#stopUpdateLoop(); // Arrêter l'ancienne boucle s'il y en a une
 
         this.updateInterval = setInterval(() => {
-            if (this.currentSession && this.onTick) {
-                const elapsed = this.currentSession.getDuration();
-                this.onTick(this.currentSession.projectId, elapsed);
+            if (this.currentSessions.length > 0 && this.onTick) {
+                // Appeler onTick pour chaque session active
+                this.currentSessions.forEach(session => {
+                    const elapsed = session.getDuration();
+                    this.onTick(session.projectId, elapsed);
+                });
             }
         }, 1000); // Mise à jour chaque seconde
     }

--- a/style.css
+++ b/style.css
@@ -478,6 +478,269 @@ body {
     box-shadow: none;
 }
 
+/* Actions container */
+.timer-compact__actions {
+    display: flex;
+    gap: var(--spacing-sm);
+    align-items: center;
+}
+
+.timer-compact__stop-all-btn {
+    padding: var(--spacing-sm) var(--spacing-md);
+    background-color: #7c3aed;
+    color: white;
+    border: none;
+    border-radius: var(--radius-md);
+    font-size: var(--font-size-sm);
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    white-space: nowrap;
+    display: none;
+}
+
+.timer-compact__stop-all-btn--visible {
+    display: inline-flex;
+}
+
+.timer-compact__stop-all-btn:hover {
+    background-color: #6d28d9;
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-md);
+}
+
+.timer-compact__stop-all-btn:disabled {
+    background-color: var(--color-border);
+    color: var(--color-text-secondary);
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+/* Toggle Mode Multi-Projet */
+.timer-compact__mode-toggle {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    padding-left: var(--spacing-md);
+    border-left: 1px solid var(--color-border);
+    margin-left: var(--spacing-md);
+}
+
+.toggle-switch {
+    position: relative;
+    display: inline-block;
+    width: 44px;
+    height: 24px;
+    cursor: pointer;
+}
+
+.toggle-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.toggle-switch__slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: var(--color-border);
+    transition: 0.3s;
+    border-radius: 24px;
+}
+
+.toggle-switch__slider:before {
+    position: absolute;
+    content: "";
+    height: 18px;
+    width: 18px;
+    left: 3px;
+    bottom: 3px;
+    background-color: white;
+    transition: 0.3s;
+    border-radius: 50%;
+    box-shadow: var(--shadow-sm);
+}
+
+.toggle-switch input:checked + .toggle-switch__slider {
+    background-color: var(--color-primary);
+}
+
+.toggle-switch input:checked + .toggle-switch__slider:before {
+    transform: translateX(20px);
+}
+
+.toggle-switch__label {
+    font-size: var(--font-size-sm);
+    font-weight: 500;
+    color: var(--color-text-secondary);
+    white-space: nowrap;
+}
+
+/* Mode multi-projet actif */
+.timer-display-compact--multi-project {
+    border-color: var(--color-primary);
+    background: linear-gradient(135deg, #eff6ff 0%, #f0fdf4 100%);
+}
+
+/* Sessions Actives */
+.active-sessions {
+    background-color: var(--color-surface);
+    border-radius: var(--radius-lg);
+    padding: var(--spacing-md) var(--spacing-lg);
+    box-shadow: var(--shadow-sm);
+    border: 2px solid var(--color-primary);
+    border-style: dashed;
+}
+
+.active-sessions__header {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    margin-bottom: var(--spacing-md);
+}
+
+.active-sessions__title {
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+    color: var(--color-text-secondary);
+}
+
+.active-sessions__count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 24px;
+    height: 24px;
+    padding: 0 var(--spacing-xs);
+    background-color: var(--color-primary);
+    color: white;
+    border-radius: 12px;
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+}
+
+.active-sessions__list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-sm);
+}
+
+.active-session-item {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    padding: var(--spacing-sm) var(--spacing-md);
+    background-color: #f0fdf4;
+    border: 1px solid var(--color-success);
+    border-radius: var(--radius-md);
+    font-size: var(--font-size-sm);
+}
+
+.active-session-item__indicator {
+    width: 8px;
+    height: 8px;
+    background-color: var(--color-success);
+    border-radius: 50%;
+    animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+    0%, 100% {
+        opacity: 1;
+        transform: scale(1);
+    }
+    50% {
+        opacity: 0.6;
+        transform: scale(0.9);
+    }
+}
+
+.active-session-item__name {
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+.active-session-item__duration {
+    color: var(--color-success);
+    font-weight: 500;
+}
+
+.active-session-item__stop-btn {
+    padding: 2px 6px;
+    background-color: transparent;
+    border: 1px solid var(--color-danger);
+    color: var(--color-danger);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    font-size: 0.75rem;
+    transition: all 0.2s ease;
+}
+
+.active-session-item__stop-btn:hover {
+    background-color: var(--color-danger);
+    color: white;
+}
+
+/* Indicateur de chevauchement (overlap) */
+.overlap-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    background-color: #fef3c7;
+    border: 1px solid #f59e0b;
+    border-radius: var(--radius-sm);
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: #92400e;
+}
+
+.overlap-indicator__icon {
+    font-size: 0.875rem;
+}
+
+/* Timeline avec chevauchements */
+.day-timeline__overlap-indicator {
+    position: absolute;
+    top: 0;
+    height: 4px;
+    background: repeating-linear-gradient(
+        45deg,
+        #f59e0b,
+        #f59e0b 4px,
+        #fbbf24 4px,
+        #fbbf24 8px
+    );
+    border-radius: 2px;
+    z-index: 10;
+}
+
+/* Badge de chevauchement dans les statistiques */
+.project-stat-card__overlap-badge {
+    position: absolute;
+    top: -8px;
+    right: -8px;
+    width: 20px;
+    height: 20px;
+    background-color: #f59e0b;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+    color: white;
+    font-weight: 600;
+    box-shadow: var(--shadow-sm);
+}
+
+.project-stat-card {
+    position: relative;
+}
+
 /* Footer */
 .footer {
     background-color: var(--color-surface);
@@ -735,6 +998,16 @@ body {
 .project-stat-card--running {
     border-color: var(--color-success);
     background-color: #f0fdf4;
+}
+
+.project-stat-card--overlap {
+    border-color: #f59e0b;
+    background: linear-gradient(135deg, #fef3c7 0%, #f0fdf4 100%);
+}
+
+.project-stat-card--running.project-stat-card--overlap {
+    border-color: var(--color-success);
+    background: linear-gradient(135deg, #fef3c7 0%, #dcfce7 100%);
 }
 
 .project-stat-card__header {


### PR DESCRIPTION
Ajout de la possibilité de travailler sur plusieurs projets simultanément:

- Nouveau toggle "Multi-projet" pour activer/désactiver le mode
- Gestion de plusieurs sessions actives en parallèle (timer.js)
- Affichage des sessions actives avec boutons d'arrêt individuels
- Visualisation des périodes de chevauchement dans les statistiques
- Badge et indicateur pour les projets travaillés en parallèle
- Arrêt automatique de tous les projets lors des pauses et départs
- Reprise automatique de tous les projets actifs après une pause