### PR TITLE
Add two-column layout with drag and drop to projects

### DIFF
--- a/app.js
+++ b/app.js
@@ -136,6 +136,14 @@ class App {
         try {
             this.projects = await this.storage.getAllProjects();
 
+            // Trier les projets par ordre (si défini), sinon par date de création
+            this.projects.sort((a, b) => {
+                if (a.order !== undefined && b.order !== undefined) {
+                    return a.order - b.order;
+                }
+                return b.createdAt.getTime() - a.createdAt.getTime();
+            });
+
             console.log(`📁 ${this.projects.length} projet(s) chargé(s)`);
 
             this.updateProjectsUI();
@@ -642,6 +650,35 @@ class App {
         }
     }
 
+    /**
+     * Réorganise les projets selon le nouvel ordre
+     * @param {string[]} projectIds - Liste des IDs de projets dans le nouvel ordre
+     */
+    async reorderProjects(projectIds) {
+        try {
+            // Mettre à jour l'ordre de chaque projet
+            projectIds.forEach((projectId, index) => {
+                const project = this.projects.find(p => p.id === projectId);
+                if (project) {
+                    project.updateOrder(index);
+                }
+            });
+
+            // Sauvegarder tous les projets avec leur nouvel ordre
+            for (const project of this.projects) {
+                await this.storage.saveProject(project);
+            }
+
+            // Réorganiser le tableau local
+            this.projects.sort((a, b) => a.order - b.order);
+
+            console.log('✅ Ordre des projets sauvegardé');
+        } catch (error) {
+            console.error('❌ Erreur lors du réordonnancement des projets:', error);
+            this.projectsUI.showError('Erreur lors du réordonnancement des projets');
+        }
+    }
+
     // ======================
     // Gestion du chronomètre
     // ======================
@@ -1007,6 +1044,11 @@ class App {
         // Ajout de temps rétroactif
         this.projectsUI.onAddRetroactiveTime = (data) => {
             this.addRetroactiveTime(data);
+        };
+
+        // Réorganisation des projets
+        this.projectsUI.onReorderProjects = (projectIds) => {
+            this.reorderProjects(projectIds);
         };
 
         console.log('✅ Écouteurs d\'événements des projets configurés');

--- a/index.html
+++ b/index.html
@@ -134,14 +134,10 @@
                     </button>
                 </div>
 
-                <!-- Tableau des projets -->
-                <table class="projects-table">
-                    <tbody id="projects-list">
-                        <tr class="projects-table__empty">
-                            <td colspan="2">Aucun projet</td>
-                        </tr>
-                    </tbody>
-                </table>
+                <!-- Grille des projets -->
+                <div id="projects-list" class="projects-grid">
+                    <div class="projects-grid__empty">Aucun projet</div>
+                </div>
             </section>
 
             <!-- Statistiques des projets -->

--- a/js/project.js
+++ b/js/project.js
@@ -7,12 +7,14 @@ export class Project {
     /**
      * @param {string} name - Nom du projet
      * @param {number} timeSpent - Temps passé en millisecondes (par défaut 0)
+     * @param {number} order - Ordre du projet dans la liste (par défaut 0)
      */
-    constructor(name, timeSpent = 0) {
+    constructor(name, timeSpent = 0, order = 0) {
         this.id = this.#generateId();
         this.name = name;
         this.timeSpent = timeSpent; // en millisecondes
         this.active = true;
+        this.order = order; // ordre dans la liste
         this.createdAt = new Date();
         this.updatedAt = new Date();
     }
@@ -63,6 +65,15 @@ export class Project {
     }
 
     /**
+     * Met à jour l'ordre du projet
+     * @param {number} order - Nouvel ordre
+     */
+    updateOrder(order) {
+        this.order = order;
+        this.updatedAt = new Date();
+    }
+
+    /**
      * Convertit le projet en objet JSON pour le stockage
      * @returns {Object}
      */
@@ -72,6 +83,7 @@ export class Project {
             name: this.name,
             timeSpent: this.timeSpent,
             active: this.active,
+            order: this.order,
             createdAt: this.createdAt.toISOString(),
             updatedAt: this.updatedAt.toISOString()
         };
@@ -88,6 +100,7 @@ export class Project {
         project.name = data.name;
         project.timeSpent = data.timeSpent || 0;
         project.active = data.active !== undefined ? data.active : true;
+        project.order = data.order !== undefined ? data.order : 0;
         project.createdAt = new Date(data.createdAt);
         project.updatedAt = new Date(data.updatedAt);
         return project;

--- a/style.css
+++ b/style.css
@@ -856,72 +856,79 @@ body {
     transform: translateY(0);
 }
 
-/* Projects Table */
-.projects-table {
+/* Projects Grid */
+.projects-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--spacing-md);
     width: 100%;
-    border-collapse: collapse;
 }
 
-.projects-table__empty td {
+.projects-grid__empty {
+    grid-column: 1 / -1;
     color: var(--color-text-secondary);
     text-align: center;
     padding: var(--spacing-xl);
     font-style: italic;
 }
 
-.projects-table__row {
-    border-bottom: 1px solid var(--color-border);
-    transition: background-color 0.2s ease;
+/* Project Card */
+.project-card {
+    background-color: var(--color-surface);
+    border: 2px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    padding: var(--spacing-md);
+    transition: all 0.3s ease;
+    cursor: move;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-md);
 }
 
-.projects-table__row:hover {
-    background-color: var(--color-background);
+.project-card:hover {
+    border-color: var(--color-primary);
+    box-shadow: var(--shadow-md);
+    transform: translateY(-2px);
 }
 
-.projects-table__row:last-child {
-    border-bottom: none;
+.project-card--dragging {
+    opacity: 0.5;
+    transform: rotate(2deg);
+    cursor: grabbing;
 }
 
-.projects-table__cell {
-    padding: var(--spacing-sm) var(--spacing-md);
+.project-card__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 }
 
-.projects-table__cell--name {
-    width: 60%;
-}
-
-.projects-table__cell--actions {
-    width: 40%;
-    text-align: right;
-}
-
-.projects-table__name {
+.project-card__name {
     font-weight: 600;
     color: var(--color-text);
-    font-size: var(--font-size-base);
+    font-size: var(--font-size-lg);
+    flex: 1;
 }
 
-.projects-table__time {
-    font-size: var(--font-size-sm);
+.project-card__time {
+    font-size: var(--font-size-base);
     color: var(--color-text-secondary);
     font-weight: 600;
     padding: var(--spacing-sm) var(--spacing-md);
     background-color: var(--color-background);
     border-radius: var(--radius-sm);
     border: 1px solid var(--color-border);
-    white-space: nowrap;
-    display: flex;
-    align-items: center;
+    text-align: center;
 }
 
-.projects-table__actions {
+.project-card__actions {
     display: flex;
     gap: var(--spacing-sm);
-    justify-content: flex-end;
+    justify-content: center;
     flex-wrap: wrap;
 }
 
-.projects-table__btn {
+.project-card__btn {
     padding: var(--spacing-sm) var(--spacing-md);
     border: 2px solid var(--color-border);
     border-radius: var(--radius-sm);
@@ -929,41 +936,44 @@ body {
     font-size: 1.2rem;
     cursor: pointer;
     transition: all 0.2s ease;
-    min-width: 40px;
+    min-width: 44px;
+    flex: 1;
 }
 
-.projects-table__btn:hover {
+.project-card__btn:hover {
     transform: translateY(-2px);
     box-shadow: var(--shadow-sm);
 }
 
-.projects-table__btn:active {
+.project-card__btn:active {
     transform: translateY(0);
 }
 
-.projects-table__btn--edit:hover {
+.project-card__btn--edit:hover {
     border-color: var(--color-primary);
     background-color: #eff6ff;
 }
 
-.projects-table__btn--time:hover {
+.project-card__btn--retroactive:hover {
     border-color: var(--color-warning);
     background-color: #fffbeb;
 }
 
-.projects-table__btn--delete:hover {
+.project-card__btn--delete:hover {
     border-color: var(--color-danger);
     background-color: #fef2f2;
 }
 
-.projects-table__btn--start:hover {
+.project-card__btn--start:hover {
     border-color: var(--color-success);
     background-color: #f0fdf4;
 }
 
-.projects-table__row--active {
-    background-color: #eff6ff;
-    border-left: 4px solid var(--color-primary);
+/* Responsive - 1 colonne sur petits écrans */
+@media (max-width: 768px) {
+    .projects-grid {
+        grid-template-columns: 1fr;
+    }
 }
 
 


### PR DESCRIPTION
- Remplace le tableau de projets par une grille CSS 2 colonnes
- Implémente le drag & drop pour réorganiser les projets
- Ajoute un champ 'order' dans la classe Project pour persister l'ordre
- Chaque carte de projet affiche le nom et les boutons d'action
- L'ordre des projets est sauvegardé et restauré automatiquement
- Responsive: 1 colonne sur petits écrans